### PR TITLE
Add retrieval of approximate country coordinate and pan map to popup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,6 +3,49 @@
 1. Leaflet Map, not rendering tiles properly (just include `import 'leaflet/dist/leaflet.css'`) - https://stackoverflow.com/questions/60296645/leaflet-map-not-rendering-tiles-properly
 2. Install npm package `@types/node` if Typescript cannot import node packages (e.g. `import dns from "node:dns"`) - https://www.npmjs.com/package/@types/node
 3. Rendering react components into non react dom nodes (for rendering JSX component to Leaflet map popup) - https://react.dev/reference/react-dom/createPortal#rendering-react-components-into-non-react-dom-nodes
+4. Countries with their (ISO 3166-1) Alpha-2 code, Alpha-3 code, UN M49, average latitude and longitude coordinates - https://gist.github.com/tadast/8827699
+5. E.g. converting CSV file to array of entries to create map
+
+```javascript
+import fs from "node:fs"
+import Papa from "papaparse"
+
+async function getCountryCoordinatesFromCsv() {
+  // Countries with their (ISO 3166-1) Alpha-2 code, Alpha-3 code, UN M49, average latitude and longitude coordinates
+  // https://gist.github.com/tadast/8827699
+  // e.g CSV
+  //   country,alpha2_code,alpha3_code,numeric_code,latitude_average,longitude_average
+  // Afghanistan,AF,AFG,4,33,65
+  const csvFile = fs.readFileSync("countryAverageCoordinates.csv", "utf8")
+  return new Promise((resolve, reject) => {
+    Papa.parse(csvFile, {
+      header: true,
+      fastMode: true,
+      error: (error) => {
+        reject(error.message)
+      },
+      complete: function (results) {
+        // latitude and longitude need to be converted from string to number
+        const data = results.data.map((countryInfo) => {
+          if (countryInfo["__parsed_extra"]) {
+            console.error(countryInfo)
+          }
+          return [
+            countryInfo["alpha2_code"],
+            {
+              latitude: parseFloat(countryInfo["latitude_average"]),
+              longitude: parseFloat(countryInfo["longitude_average"]),
+            },
+          ]
+        })
+        // @ts-expect-error converting data to map using iterable [[key, value]]
+        const map = new Map(data)
+        resolve(map)
+      },
+    })
+  })
+}
+```
 
 # React + TypeScript + Vite
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,26 +3,25 @@ import { getRandomStation } from "./api/radiobrowser/station"
 import "./App.css"
 import Map from "./features/map/components/Map/Map"
 import RadioSelect from "./features/radioselect/components/RadioSelect/RadioSelect"
-import RadioCard from "./features/map/components/RadioCard/RadioCard"
 import Header from "./components/Header/Header"
+import { Station } from "./api/radiobrowser/types"
 
 function App() {
-  const [popupContent, setPopupContent] = useState<JSX.Element | null>(null)
+  const [currentStation, setCurrentStation] = useState<Station | null>(null)
 
   async function displayRandomStation() {
     const station = await getRandomStation()
     if (station) {
       // TODO remove debug log
       console.log(JSON.stringify(station, null, 2))
-      // display on map as popup, of radio card
-      setPopupContent(<RadioCard station={station} />)
+      setCurrentStation(station)
     }
   }
   return (
     <>
       <Header />
       <RadioSelect handleRandomSelect={displayRandomStation} />
-      <Map popupContent={popupContent} />
+      <Map station={currentStation} />
     </>
   )
 }

--- a/frontend/src/api/location/country.ts
+++ b/frontend/src/api/location/country.ts
@@ -1,0 +1,14 @@
+import { countryAlpha2ToCoordinate } from "./countryCoordinate"
+
+type Coordinates = {
+  latitude: number
+  longitude: number
+}
+
+function getCountryCoordinateBasedOn(
+  alpha2Code: string
+): Coordinates | undefined {
+  return countryAlpha2ToCoordinate.get(alpha2Code.toUpperCase())
+}
+
+export { getCountryCoordinateBasedOn }

--- a/frontend/src/api/location/countryAverageCoordinates.csv
+++ b/frontend/src/api/location/countryAverageCoordinates.csv
@@ -1,0 +1,254 @@
+country,alpha2_code,alpha3_code,numeric_code,latitude_average,longitude_average
+Afghanistan,AF,AFG,4,33,65
+Åland Islands,AX,ALA,248,60.116667,19.9
+Albania,AL,ALB,8,41,20
+Algeria,DZ,DZA,12,28,3
+American Samoa,AS,ASM,16,-14.3333,-170
+Andorra,AD,AND,20,42.5,1.6
+Angola,AO,AGO,24,-12.5,18.5
+Anguilla,AI,AIA,660,18.25,-63.1667
+Antarctica,AQ,ATA,10,-90,0
+Antigua and Barbuda,AG,ATG,28,17.05,-61.8
+Argentina,AR,ARG,32,-34,-64
+Armenia,AM,ARM,51,40,45
+Aruba,AW,ABW,533,12.5,-69.9667
+Australia,AU,AUS,36,-27,133
+Austria,AT,AUT,40,47.3333,13.3333
+Azerbaijan,AZ,AZE,31,40.5,47.5
+Bahamas,BS,BHS,44,24.25,-76
+Bahrain,BH,BHR,48,26,50.55
+Bangladesh,BD,BGD,50,24,90
+Barbados,BB,BRB,52,13.1667,-59.5333
+Belarus,BY,BLR,112,53,28
+Belgium,BE,BEL,56,50.8333,4
+Belize,BZ,BLZ,84,17.25,-88.75
+Benin,BJ,BEN,204,9.5,2.25
+Bermuda,BM,BMU,60,32.3333,-64.75
+Bhutan,BT,BTN,64,27.5,90.5
+Bolivia,BO,BOL,68,-17,-65
+Bonaire Sint Eustatius and Saba,BQ,BES,535,12.183333,-68.233333
+Bosnia and Herzegovina,BA,BIH,70,44,18
+Botswana,BW,BWA,72,-22,24
+Bouvet Island,BV,BVT,74,-54.4333,3.4
+Brazil,BR,BRA,76,-10,-55
+British Indian Ocean Territory,IO,IOT,86,-6,71.5
+Brunei,BN,BRN,96,4.5,114.6667
+Bulgaria,BG,BGR,100,43,25
+Burkina Faso,BF,BFA,854,13,-2
+Burma,MM,MMR,104,22,98
+Burundi,BI,BDI,108,-3.5,30
+Cambodia,KH,KHM,116,13,105
+Cameroon,CM,CMR,120,6,12
+Canada,CA,CAN,124,60,-95
+Cape Verde,CV,CPV,132,16,-24
+Cayman Islands,KY,CYM,136,19.5,-80.5
+Central African Republic,CF,CAF,140,7,21
+Chad,TD,TCD,148,15,19
+Chile,CL,CHL,152,-30,-71
+China,CN,CHN,156,35,105
+Christmas Island,CX,CXR,162,-10.5,105.6667
+Cocos (Keeling) Islands,CC,CCK,166,-12.5,96.8333
+Colombia,CO,COL,170,4,-72
+Comoros,KM,COM,174,-12.1667,44.25
+DR Congo,CD,COD,180,0,25
+Congo,CG,COG,178,-1,15
+Cook Islands,CK,COK,184,-21.2333,-159.7667
+Costa Rica,CR,CRI,188,10,-84
+Côte d'Ivoire,CI,CIV,384,8,-5
+Croatia,HR,HRV,191,45.1667,15.5
+Cuba,CU,CUB,192,21.5,-80
+Curaçao,CW,CUW,531,12.166667,-68.966667
+Cyprus,CY,CYP,196,35,33
+Czech Republic,CZ,CZE,203,49.75,15.5
+Denmark,DK,DNK,208,56,10
+Djibouti,DJ,DJI,262,11.5,43
+Dominica,DM,DMA,212,15.4167,-61.3333
+Dominican Republic,DO,DOM,214,19,-70.6667
+Ecuador,EC,ECU,218,-2,-77.5
+Egypt,EG,EGY,818,27,30
+El Salvador,SV,SLV,222,13.8333,-88.9167
+Equatorial Guinea,GQ,GNQ,226,2,10
+Eritrea,ER,ERI,232,15,39
+Estonia,EE,EST,233,59,26
+Ethiopia,ET,ETH,231,8,38
+Falkland Islands (Malvinas),FK,FLK,238,-51.75,-59
+Faroe Islands,FO,FRO,234,62,-7
+Fiji,FJ,FJI,242,-18,175
+Finland,FI,FIN,246,64,26
+France,FR,FRA,250,46,2
+French Guiana,GF,GUF,254,4,-53
+French Polynesia,PF,PYF,258,-15,-140
+French Southern Territories,TF,ATF,260,-43,67
+Gabon,GA,GAB,266,-1,11.75
+Gambia,GM,GMB,270,13.4667,-16.5667
+Georgia,GE,GEO,268,42,43.5
+Germany,DE,DEU,276,51,9
+Ghana,GH,GHA,288,8,-2
+Gibraltar,GI,GIB,292,36.1833,-5.3667
+Greece,GR,GRC,300,39,22
+Greenland,GL,GRL,304,72,-40
+Grenada,GD,GRD,308,12.1167,-61.6667
+Guadeloupe,GP,GLP,312,16.25,-61.5833
+Guam,GU,GUM,316,13.4667,144.7833
+Guatemala,GT,GTM,320,15.5,-90.25
+Guernsey,GG,GGY,831,49.5,-2.56
+Guinea-Bissau,GW,GNB,624,12,-15
+Guinea,GN,GIN,324,11,-10
+Guyana,GY,GUY,328,5,-59
+Haiti,HT,HTI,332,19,-72.4167
+Heard Island and McDonald Islands,HM,HMD,334,-53.1,72.5167
+Holy See (Vatican City State),VA,VAT,336,41.9,12.45
+Honduras,HN,HND,340,15,-86.5
+Hong Kong,HK,HKG,344,22.25,114.1667
+Hungary,HU,HUN,348,47,20
+Iceland,IS,ISL,352,65,-18
+India,IN,IND,356,20,77
+Indonesia,ID,IDN,360,-5,120
+Iran,IR,IRN,364,32,53
+Iraq,IQ,IRQ,368,33,44
+Ireland,IE,IRL,372,53,-8
+Isle of Man,IM,IMN,833,54.23,-4.55
+Israel,IL,ISR,376,31.5,34.75
+Italy,IT,ITA,380,42.8333,12.8333
+Ivory Coast,CI,CIV,384,8,-5
+Jamaica,JM,JAM,388,18.25,-77.5
+Japan,JP,JPN,392,36,138
+Jersey,JE,JEY,832,49.21,-2.13
+Jordan,JO,JOR,400,31,36
+Kazakhstan,KZ,KAZ,398,48,68
+Kenya,KE,KEN,404,1,38
+Kiribati,KI,KIR,296,1.4167,173
+North Korea,KP,PRK,408,40,127
+Kosovo,XK,XKX,95,42.583333,21
+Kuwait,KW,KWT,414,29.3375,47.6581
+Kyrgyzstan,KG,KGZ,417,41,75
+Lao People's Democratic Republic,LA,LAO,418,18,105
+Latvia,LV,LVA,428,57,25
+Lebanon,LB,LBN,422,33.8333,35.8333
+Lesotho,LS,LSO,426,-29.5,28.5
+Liberia,LR,LBR,430,6.5,-9.5
+Libya,LY,LBY,434,25,17
+Liechtenstein,LI,LIE,438,47.1667,9.5333
+Lithuania,LT,LTU,440,56,24
+Luxembourg,LU,LUX,442,49.75,6.1667
+Macao,MO,MAC,446,22.1667,113.55
+Macedonia,MK,MKD,807,41.8333,22
+Madagascar,MG,MDG,450,-20,47
+Malawi,MW,MWI,454,-13.5,34
+Malaysia,MY,MYS,458,2.5,112.5
+Maldives,MV,MDV,462,3.25,73
+Mali,ML,MLI,466,17,-4
+Malta,MT,MLT,470,35.8333,14.5833
+Marshall Islands,MH,MHL,584,9,168
+Martinique,MQ,MTQ,474,14.6667,-61
+Mauritania,MR,MRT,478,20,-12
+Mauritius,MU,MUS,480,-20.2833,57.55
+Mayotte,YT,MYT,175,-12.8333,45.1667
+Mexico,MX,MEX,484,23,-102
+Micronesia,FM,FSM,583,6.9167,158.25
+Moldova,MD,MDA,498,47,29
+Monaco,MC,MCO,492,43.7333,7.4
+Mongolia,MN,MNG,496,46,105
+Montenegro,ME,MNE,499,42,19
+Montserrat,MS,MSR,500,16.75,-62.2
+Morocco,MA,MAR,504,32,-5
+Mozambique,MZ,MOZ,508,-18.25,35
+Myanmar,MM,MMR,104,22,98
+Namibia,NA,NAM,516,-22,17
+Nauru,NR,NRU,520,-0.5333,166.9167
+Nepal,NP,NPL,524,28,84
+Netherlands Antilles,AN,ANT,530,12.25,-68.75
+Netherlands,NL,NLD,528,52.5,5.75
+New Caledonia,NC,NCL,540,-21.5,165.5
+New Zealand,NZ,NZL,554,-41,174
+Nicaragua,NI,NIC,558,13,-85
+Niger,NE,NER,562,16,8
+Nigeria,NG,NGA,566,10,8
+Niue,NU,NIU,570,-19.0333,-169.8667
+Norfolk Island,NF,NFK,574,-29.0333,167.95
+Northern Mariana Islands,MP,MNP,580,15.2,145.75
+Norway,NO,NOR,578,62,10
+Oman,OM,OMN,512,21,57
+Pakistan,PK,PAK,586,30,70
+Palau,PW,PLW,585,7.5,134.5
+Palestine,PS,PSE,275,32,35.25
+Panama,PA,PAN,591,9,-80
+Papua New Guinea,PG,PNG,598,-6,147
+Paraguay,PY,PRY,600,-23,-58
+Peru,PE,PER,604,-10,-76
+Philippines,PH,PHL,608,13,122
+Pitcairn,PN,PCN,612,-24.7,-127.4
+Poland,PL,POL,616,52,20
+Portugal,PT,PRT,620,39.5,-8
+Puerto Rico,PR,PRI,630,18.25,-66.5
+Qatar,QA,QAT,634,25.5,51.25
+Réunion,RE,REU,638,-21.1,55.6
+Romania,RO,ROU,642,46,25
+Russian Federation,RU,RUS,643,60,100
+Rwanda,RW,RWA,646,-2,30
+Saint Barthélemy,BL,BLM,652,17.897728,-62.834244
+Saint Helena Ascension and Tristan da Cunha,SH,SHN,654,-15.9333,-5.7
+Saint Kitts and Nevis,KN,KNA,659,17.3333,-62.75
+Saint Lucia,LC,LCA,662,13.8833,-61.1333
+Saint Martin (French part),MF,MAF,663,18.075278,-63.06
+Saint Pierre and Miquelon,PM,SPM,666,46.8333,-56.3333
+Saint Vincent and the Grenadines,VC,VCT,670,13.25,-61.2
+Samoa,WS,WSM,882,-13.5833,-172.3333
+San Marino,SM,SMR,674,43.7667,12.4167
+Sao Tome and Principe,ST,STP,678,1,7
+Saudi Arabia,SA,SAU,682,25,45
+Senegal,SN,SEN,686,14,-14
+Serbia,RS,SRB,688,44,21
+Seychelles,SC,SYC,690,-4.5833,55.6667
+Sierra Leone,SL,SLE,694,8.5,-11.5
+Singapore,SG,SGP,702,1.3667,103.8
+Sint Maarten (Dutch part),SX,SXM,534,18.033333,-63.05
+Slovakia,SK,SVK,703,48.6667,19.5
+Slovenia,SI,SVN,705,46,15
+Solomon Islands,SB,SLB,90,-8,159
+Somalia,SO,SOM,706,10,49
+South Africa,ZA,ZAF,710,-29,24
+South Georgia and the South Sandwich Islands,GS,SGS,239,-54.5,-37
+South Korea,KR,KOR,410,37,127.5
+South Sudan,SS,SSD,728,8,30
+Spain,ES,ESP,724,40,-4
+Sri Lanka,LK,LKA,144,7,81
+Sudan,SD,SDN,736,15,30
+Suriname,SR,SUR,740,4,-56
+Svalbard and Jan Mayen,SJ,SJM,744,78,20
+Swaziland,SZ,SWZ,748,-26.5,31.5
+Sweden,SE,SWE,752,62,15
+Switzerland,CH,CHE,756,47,8
+Syrian Arab Republic,SY,SYR,760,35,38
+Taiwan,TW,TWN,158,23.5,121
+Tajikistan,TJ,TJK,762,39,71
+Tanzania,TZ,TZA,834,-6,35
+Thailand,TH,THA,764,15,100
+Timor-Leste,TL,TLS,626,-8.55,125.5167
+Togo,TG,TGO,768,8,1.1667
+Tokelau,TK,TKL,772,-9,-172
+Tonga,TO,TON,776,-20,-175
+Trinidad and Tobago,TT,TTO,780,11,-61
+Tunisia,TN,TUN,788,34,9
+Turkey,TR,TUR,792,39,35
+Turkmenistan,TM,TKM,795,40,60
+Turks and Caicos Islands,TC,TCA,796,21.75,-71.5833
+Tuvalu,TV,TUV,798,-8,178
+Uganda,UG,UGA,800,1,32
+Ukraine,UA,UKR,804,49,32
+United Arab Emirates,AE,ARE,784,24,54
+United Kingdom,GB,GBR,826,54,-2
+United States Minor Outlying Islands,UM,UMI,581,19.2833,166.6
+United States,US,USA,840,38,-97
+Uruguay,UY,URY,858,-33,-56
+Uzbekistan,UZ,UZB,860,41,64
+Vanuatu,VU,VUT,548,-16,167
+Venezuela,VE,VEN,862,8,-66
+Vietnam,VN,VNM,704,16,106
+Virgin Islands (British),VG,VGB,92,18.5,-64.5
+Virgin Islands (U.S),VI,VIR,850,18.3333,-64.8333
+Wallis and Futuna,WF,WLF,876,-13.3,-176.2
+Western Sahara,EH,ESH,732,24.5,-13
+Yemen,YE,YEM,887,15,48
+Zambia,ZM,ZMB,894,-15,30
+Zimbabwe,ZW,ZWE,716,-20,30

--- a/frontend/src/api/location/countryCoordinate.ts
+++ b/frontend/src/api/location/countryCoordinate.ts
@@ -1,0 +1,1774 @@
+// Alpha 2 country code - https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+export const countryAlpha2ToCoordinate = new Map([
+  [
+    "AF",
+    {
+      latitude: 33,
+      longitude: 65,
+    },
+  ],
+  [
+    "AX",
+    {
+      latitude: 60.116667,
+      longitude: 19.9,
+    },
+  ],
+  [
+    "AL",
+    {
+      latitude: 41,
+      longitude: 20,
+    },
+  ],
+  [
+    "DZ",
+    {
+      latitude: 28,
+      longitude: 3,
+    },
+  ],
+  [
+    "AS",
+    {
+      latitude: -14.3333,
+      longitude: -170,
+    },
+  ],
+  [
+    "AD",
+    {
+      latitude: 42.5,
+      longitude: 1.6,
+    },
+  ],
+  [
+    "AO",
+    {
+      latitude: -12.5,
+      longitude: 18.5,
+    },
+  ],
+  [
+    "AI",
+    {
+      latitude: 18.25,
+      longitude: -63.1667,
+    },
+  ],
+  [
+    "AQ",
+    {
+      latitude: -90,
+      longitude: 0,
+    },
+  ],
+  [
+    "AG",
+    {
+      latitude: 17.05,
+      longitude: -61.8,
+    },
+  ],
+  [
+    "AR",
+    {
+      latitude: -34,
+      longitude: -64,
+    },
+  ],
+  [
+    "AM",
+    {
+      latitude: 40,
+      longitude: 45,
+    },
+  ],
+  [
+    "AW",
+    {
+      latitude: 12.5,
+      longitude: -69.9667,
+    },
+  ],
+  [
+    "AU",
+    {
+      latitude: -27,
+      longitude: 133,
+    },
+  ],
+  [
+    "AT",
+    {
+      latitude: 47.3333,
+      longitude: 13.3333,
+    },
+  ],
+  [
+    "AZ",
+    {
+      latitude: 40.5,
+      longitude: 47.5,
+    },
+  ],
+  [
+    "BS",
+    {
+      latitude: 24.25,
+      longitude: -76,
+    },
+  ],
+  [
+    "BH",
+    {
+      latitude: 26,
+      longitude: 50.55,
+    },
+  ],
+  [
+    "BD",
+    {
+      latitude: 24,
+      longitude: 90,
+    },
+  ],
+  [
+    "BB",
+    {
+      latitude: 13.1667,
+      longitude: -59.5333,
+    },
+  ],
+  [
+    "BY",
+    {
+      latitude: 53,
+      longitude: 28,
+    },
+  ],
+  [
+    "BE",
+    {
+      latitude: 50.8333,
+      longitude: 4,
+    },
+  ],
+  [
+    "BZ",
+    {
+      latitude: 17.25,
+      longitude: -88.75,
+    },
+  ],
+  [
+    "BJ",
+    {
+      latitude: 9.5,
+      longitude: 2.25,
+    },
+  ],
+  [
+    "BM",
+    {
+      latitude: 32.3333,
+      longitude: -64.75,
+    },
+  ],
+  [
+    "BT",
+    {
+      latitude: 27.5,
+      longitude: 90.5,
+    },
+  ],
+  [
+    "BO",
+    {
+      latitude: -17,
+      longitude: -65,
+    },
+  ],
+  [
+    "BQ",
+    {
+      latitude: 12.183333,
+      longitude: -68.233333,
+    },
+  ],
+  [
+    "BA",
+    {
+      latitude: 44,
+      longitude: 18,
+    },
+  ],
+  [
+    "BW",
+    {
+      latitude: -22,
+      longitude: 24,
+    },
+  ],
+  [
+    "BV",
+    {
+      latitude: -54.4333,
+      longitude: 3.4,
+    },
+  ],
+  [
+    "BR",
+    {
+      latitude: -10,
+      longitude: -55,
+    },
+  ],
+  [
+    "IO",
+    {
+      latitude: -6,
+      longitude: 71.5,
+    },
+  ],
+  [
+    "BN",
+    {
+      latitude: 4.5,
+      longitude: 114.6667,
+    },
+  ],
+  [
+    "BG",
+    {
+      latitude: 43,
+      longitude: 25,
+    },
+  ],
+  [
+    "BF",
+    {
+      latitude: 13,
+      longitude: -2,
+    },
+  ],
+  [
+    "MM",
+    {
+      latitude: 22,
+      longitude: 98,
+    },
+  ],
+  [
+    "BI",
+    {
+      latitude: -3.5,
+      longitude: 30,
+    },
+  ],
+  [
+    "KH",
+    {
+      latitude: 13,
+      longitude: 105,
+    },
+  ],
+  [
+    "CM",
+    {
+      latitude: 6,
+      longitude: 12,
+    },
+  ],
+  [
+    "CA",
+    {
+      latitude: 60,
+      longitude: -95,
+    },
+  ],
+  [
+    "CV",
+    {
+      latitude: 16,
+      longitude: -24,
+    },
+  ],
+  [
+    "KY",
+    {
+      latitude: 19.5,
+      longitude: -80.5,
+    },
+  ],
+  [
+    "CF",
+    {
+      latitude: 7,
+      longitude: 21,
+    },
+  ],
+  [
+    "TD",
+    {
+      latitude: 15,
+      longitude: 19,
+    },
+  ],
+  [
+    "CL",
+    {
+      latitude: -30,
+      longitude: -71,
+    },
+  ],
+  [
+    "CN",
+    {
+      latitude: 35,
+      longitude: 105,
+    },
+  ],
+  [
+    "CX",
+    {
+      latitude: -10.5,
+      longitude: 105.6667,
+    },
+  ],
+  [
+    "CC",
+    {
+      latitude: -12.5,
+      longitude: 96.8333,
+    },
+  ],
+  [
+    "CO",
+    {
+      latitude: 4,
+      longitude: -72,
+    },
+  ],
+  [
+    "KM",
+    {
+      latitude: -12.1667,
+      longitude: 44.25,
+    },
+  ],
+  [
+    "CD",
+    {
+      latitude: 0,
+      longitude: 25,
+    },
+  ],
+  [
+    "CG",
+    {
+      latitude: -1,
+      longitude: 15,
+    },
+  ],
+  [
+    "CK",
+    {
+      latitude: -21.2333,
+      longitude: -159.7667,
+    },
+  ],
+  [
+    "CR",
+    {
+      latitude: 10,
+      longitude: -84,
+    },
+  ],
+  [
+    "CI",
+    {
+      latitude: 8,
+      longitude: -5,
+    },
+  ],
+  [
+    "HR",
+    {
+      latitude: 45.1667,
+      longitude: 15.5,
+    },
+  ],
+  [
+    "CU",
+    {
+      latitude: 21.5,
+      longitude: -80,
+    },
+  ],
+  [
+    "CW",
+    {
+      latitude: 12.166667,
+      longitude: -68.966667,
+    },
+  ],
+  [
+    "CY",
+    {
+      latitude: 35,
+      longitude: 33,
+    },
+  ],
+  [
+    "CZ",
+    {
+      latitude: 49.75,
+      longitude: 15.5,
+    },
+  ],
+  [
+    "DK",
+    {
+      latitude: 56,
+      longitude: 10,
+    },
+  ],
+  [
+    "DJ",
+    {
+      latitude: 11.5,
+      longitude: 43,
+    },
+  ],
+  [
+    "DM",
+    {
+      latitude: 15.4167,
+      longitude: -61.3333,
+    },
+  ],
+  [
+    "DO",
+    {
+      latitude: 19,
+      longitude: -70.6667,
+    },
+  ],
+  [
+    "EC",
+    {
+      latitude: -2,
+      longitude: -77.5,
+    },
+  ],
+  [
+    "EG",
+    {
+      latitude: 27,
+      longitude: 30,
+    },
+  ],
+  [
+    "SV",
+    {
+      latitude: 13.8333,
+      longitude: -88.9167,
+    },
+  ],
+  [
+    "GQ",
+    {
+      latitude: 2,
+      longitude: 10,
+    },
+  ],
+  [
+    "ER",
+    {
+      latitude: 15,
+      longitude: 39,
+    },
+  ],
+  [
+    "EE",
+    {
+      latitude: 59,
+      longitude: 26,
+    },
+  ],
+  [
+    "ET",
+    {
+      latitude: 8,
+      longitude: 38,
+    },
+  ],
+  [
+    "FK",
+    {
+      latitude: -51.75,
+      longitude: -59,
+    },
+  ],
+  [
+    "FO",
+    {
+      latitude: 62,
+      longitude: -7,
+    },
+  ],
+  [
+    "FJ",
+    {
+      latitude: -18,
+      longitude: 175,
+    },
+  ],
+  [
+    "FI",
+    {
+      latitude: 64,
+      longitude: 26,
+    },
+  ],
+  [
+    "FR",
+    {
+      latitude: 46,
+      longitude: 2,
+    },
+  ],
+  [
+    "GF",
+    {
+      latitude: 4,
+      longitude: -53,
+    },
+  ],
+  [
+    "PF",
+    {
+      latitude: -15,
+      longitude: -140,
+    },
+  ],
+  [
+    "TF",
+    {
+      latitude: -43,
+      longitude: 67,
+    },
+  ],
+  [
+    "GA",
+    {
+      latitude: -1,
+      longitude: 11.75,
+    },
+  ],
+  [
+    "GM",
+    {
+      latitude: 13.4667,
+      longitude: -16.5667,
+    },
+  ],
+  [
+    "GE",
+    {
+      latitude: 42,
+      longitude: 43.5,
+    },
+  ],
+  [
+    "DE",
+    {
+      latitude: 51,
+      longitude: 9,
+    },
+  ],
+  [
+    "GH",
+    {
+      latitude: 8,
+      longitude: -2,
+    },
+  ],
+  [
+    "GI",
+    {
+      latitude: 36.1833,
+      longitude: -5.3667,
+    },
+  ],
+  [
+    "GR",
+    {
+      latitude: 39,
+      longitude: 22,
+    },
+  ],
+  [
+    "GL",
+    {
+      latitude: 72,
+      longitude: -40,
+    },
+  ],
+  [
+    "GD",
+    {
+      latitude: 12.1167,
+      longitude: -61.6667,
+    },
+  ],
+  [
+    "GP",
+    {
+      latitude: 16.25,
+      longitude: -61.5833,
+    },
+  ],
+  [
+    "GU",
+    {
+      latitude: 13.4667,
+      longitude: 144.7833,
+    },
+  ],
+  [
+    "GT",
+    {
+      latitude: 15.5,
+      longitude: -90.25,
+    },
+  ],
+  [
+    "GG",
+    {
+      latitude: 49.5,
+      longitude: -2.56,
+    },
+  ],
+  [
+    "GW",
+    {
+      latitude: 12,
+      longitude: -15,
+    },
+  ],
+  [
+    "GN",
+    {
+      latitude: 11,
+      longitude: -10,
+    },
+  ],
+  [
+    "GY",
+    {
+      latitude: 5,
+      longitude: -59,
+    },
+  ],
+  [
+    "HT",
+    {
+      latitude: 19,
+      longitude: -72.4167,
+    },
+  ],
+  [
+    "HM",
+    {
+      latitude: -53.1,
+      longitude: 72.5167,
+    },
+  ],
+  [
+    "VA",
+    {
+      latitude: 41.9,
+      longitude: 12.45,
+    },
+  ],
+  [
+    "HN",
+    {
+      latitude: 15,
+      longitude: -86.5,
+    },
+  ],
+  [
+    "HK",
+    {
+      latitude: 22.25,
+      longitude: 114.1667,
+    },
+  ],
+  [
+    "HU",
+    {
+      latitude: 47,
+      longitude: 20,
+    },
+  ],
+  [
+    "IS",
+    {
+      latitude: 65,
+      longitude: -18,
+    },
+  ],
+  [
+    "IN",
+    {
+      latitude: 20,
+      longitude: 77,
+    },
+  ],
+  [
+    "ID",
+    {
+      latitude: -5,
+      longitude: 120,
+    },
+  ],
+  [
+    "IR",
+    {
+      latitude: 32,
+      longitude: 53,
+    },
+  ],
+  [
+    "IQ",
+    {
+      latitude: 33,
+      longitude: 44,
+    },
+  ],
+  [
+    "IE",
+    {
+      latitude: 53,
+      longitude: -8,
+    },
+  ],
+  [
+    "IM",
+    {
+      latitude: 54.23,
+      longitude: -4.55,
+    },
+  ],
+  [
+    "IL",
+    {
+      latitude: 31.5,
+      longitude: 34.75,
+    },
+  ],
+  [
+    "IT",
+    {
+      latitude: 42.8333,
+      longitude: 12.8333,
+    },
+  ],
+  [
+    "CI",
+    {
+      latitude: 8,
+      longitude: -5,
+    },
+  ],
+  [
+    "JM",
+    {
+      latitude: 18.25,
+      longitude: -77.5,
+    },
+  ],
+  [
+    "JP",
+    {
+      latitude: 36,
+      longitude: 138,
+    },
+  ],
+  [
+    "JE",
+    {
+      latitude: 49.21,
+      longitude: -2.13,
+    },
+  ],
+  [
+    "JO",
+    {
+      latitude: 31,
+      longitude: 36,
+    },
+  ],
+  [
+    "KZ",
+    {
+      latitude: 48,
+      longitude: 68,
+    },
+  ],
+  [
+    "KE",
+    {
+      latitude: 1,
+      longitude: 38,
+    },
+  ],
+  [
+    "KI",
+    {
+      latitude: 1.4167,
+      longitude: 173,
+    },
+  ],
+  [
+    "KP",
+    {
+      latitude: 40,
+      longitude: 127,
+    },
+  ],
+  [
+    "XK",
+    {
+      latitude: 42.583333,
+      longitude: 21,
+    },
+  ],
+  [
+    "KW",
+    {
+      latitude: 29.3375,
+      longitude: 47.6581,
+    },
+  ],
+  [
+    "KG",
+    {
+      latitude: 41,
+      longitude: 75,
+    },
+  ],
+  [
+    "LA",
+    {
+      latitude: 18,
+      longitude: 105,
+    },
+  ],
+  [
+    "LV",
+    {
+      latitude: 57,
+      longitude: 25,
+    },
+  ],
+  [
+    "LB",
+    {
+      latitude: 33.8333,
+      longitude: 35.8333,
+    },
+  ],
+  [
+    "LS",
+    {
+      latitude: -29.5,
+      longitude: 28.5,
+    },
+  ],
+  [
+    "LR",
+    {
+      latitude: 6.5,
+      longitude: -9.5,
+    },
+  ],
+  [
+    "LY",
+    {
+      latitude: 25,
+      longitude: 17,
+    },
+  ],
+  [
+    "LI",
+    {
+      latitude: 47.1667,
+      longitude: 9.5333,
+    },
+  ],
+  [
+    "LT",
+    {
+      latitude: 56,
+      longitude: 24,
+    },
+  ],
+  [
+    "LU",
+    {
+      latitude: 49.75,
+      longitude: 6.1667,
+    },
+  ],
+  [
+    "MO",
+    {
+      latitude: 22.1667,
+      longitude: 113.55,
+    },
+  ],
+  [
+    "MK",
+    {
+      latitude: 41.8333,
+      longitude: 22,
+    },
+  ],
+  [
+    "MG",
+    {
+      latitude: -20,
+      longitude: 47,
+    },
+  ],
+  [
+    "MW",
+    {
+      latitude: -13.5,
+      longitude: 34,
+    },
+  ],
+  [
+    "MY",
+    {
+      latitude: 2.5,
+      longitude: 112.5,
+    },
+  ],
+  [
+    "MV",
+    {
+      latitude: 3.25,
+      longitude: 73,
+    },
+  ],
+  [
+    "ML",
+    {
+      latitude: 17,
+      longitude: -4,
+    },
+  ],
+  [
+    "MT",
+    {
+      latitude: 35.8333,
+      longitude: 14.5833,
+    },
+  ],
+  [
+    "MH",
+    {
+      latitude: 9,
+      longitude: 168,
+    },
+  ],
+  [
+    "MQ",
+    {
+      latitude: 14.6667,
+      longitude: -61,
+    },
+  ],
+  [
+    "MR",
+    {
+      latitude: 20,
+      longitude: -12,
+    },
+  ],
+  [
+    "MU",
+    {
+      latitude: -20.2833,
+      longitude: 57.55,
+    },
+  ],
+  [
+    "YT",
+    {
+      latitude: -12.8333,
+      longitude: 45.1667,
+    },
+  ],
+  [
+    "MX",
+    {
+      latitude: 23,
+      longitude: -102,
+    },
+  ],
+  [
+    "FM",
+    {
+      latitude: 6.9167,
+      longitude: 158.25,
+    },
+  ],
+  [
+    "MD",
+    {
+      latitude: 47,
+      longitude: 29,
+    },
+  ],
+  [
+    "MC",
+    {
+      latitude: 43.7333,
+      longitude: 7.4,
+    },
+  ],
+  [
+    "MN",
+    {
+      latitude: 46,
+      longitude: 105,
+    },
+  ],
+  [
+    "ME",
+    {
+      latitude: 42,
+      longitude: 19,
+    },
+  ],
+  [
+    "MS",
+    {
+      latitude: 16.75,
+      longitude: -62.2,
+    },
+  ],
+  [
+    "MA",
+    {
+      latitude: 32,
+      longitude: -5,
+    },
+  ],
+  [
+    "MZ",
+    {
+      latitude: -18.25,
+      longitude: 35,
+    },
+  ],
+  [
+    "MM",
+    {
+      latitude: 22,
+      longitude: 98,
+    },
+  ],
+  [
+    "NA",
+    {
+      latitude: -22,
+      longitude: 17,
+    },
+  ],
+  [
+    "NR",
+    {
+      latitude: -0.5333,
+      longitude: 166.9167,
+    },
+  ],
+  [
+    "NP",
+    {
+      latitude: 28,
+      longitude: 84,
+    },
+  ],
+  [
+    "AN",
+    {
+      latitude: 12.25,
+      longitude: -68.75,
+    },
+  ],
+  [
+    "NL",
+    {
+      latitude: 52.5,
+      longitude: 5.75,
+    },
+  ],
+  [
+    "NC",
+    {
+      latitude: -21.5,
+      longitude: 165.5,
+    },
+  ],
+  [
+    "NZ",
+    {
+      latitude: -41,
+      longitude: 174,
+    },
+  ],
+  [
+    "NI",
+    {
+      latitude: 13,
+      longitude: -85,
+    },
+  ],
+  [
+    "NE",
+    {
+      latitude: 16,
+      longitude: 8,
+    },
+  ],
+  [
+    "NG",
+    {
+      latitude: 10,
+      longitude: 8,
+    },
+  ],
+  [
+    "NU",
+    {
+      latitude: -19.0333,
+      longitude: -169.8667,
+    },
+  ],
+  [
+    "NF",
+    {
+      latitude: -29.0333,
+      longitude: 167.95,
+    },
+  ],
+  [
+    "MP",
+    {
+      latitude: 15.2,
+      longitude: 145.75,
+    },
+  ],
+  [
+    "NO",
+    {
+      latitude: 62,
+      longitude: 10,
+    },
+  ],
+  [
+    "OM",
+    {
+      latitude: 21,
+      longitude: 57,
+    },
+  ],
+  [
+    "PK",
+    {
+      latitude: 30,
+      longitude: 70,
+    },
+  ],
+  [
+    "PW",
+    {
+      latitude: 7.5,
+      longitude: 134.5,
+    },
+  ],
+  [
+    "PS",
+    {
+      latitude: 32,
+      longitude: 35.25,
+    },
+  ],
+  [
+    "PA",
+    {
+      latitude: 9,
+      longitude: -80,
+    },
+  ],
+  [
+    "PG",
+    {
+      latitude: -6,
+      longitude: 147,
+    },
+  ],
+  [
+    "PY",
+    {
+      latitude: -23,
+      longitude: -58,
+    },
+  ],
+  [
+    "PE",
+    {
+      latitude: -10,
+      longitude: -76,
+    },
+  ],
+  [
+    "PH",
+    {
+      latitude: 13,
+      longitude: 122,
+    },
+  ],
+  [
+    "PN",
+    {
+      latitude: -24.7,
+      longitude: -127.4,
+    },
+  ],
+  [
+    "PL",
+    {
+      latitude: 52,
+      longitude: 20,
+    },
+  ],
+  [
+    "PT",
+    {
+      latitude: 39.5,
+      longitude: -8,
+    },
+  ],
+  [
+    "PR",
+    {
+      latitude: 18.25,
+      longitude: -66.5,
+    },
+  ],
+  [
+    "QA",
+    {
+      latitude: 25.5,
+      longitude: 51.25,
+    },
+  ],
+  [
+    "RE",
+    {
+      latitude: -21.1,
+      longitude: 55.6,
+    },
+  ],
+  [
+    "RO",
+    {
+      latitude: 46,
+      longitude: 25,
+    },
+  ],
+  [
+    "RU",
+    {
+      latitude: 60,
+      longitude: 100,
+    },
+  ],
+  [
+    "RW",
+    {
+      latitude: -2,
+      longitude: 30,
+    },
+  ],
+  [
+    "BL",
+    {
+      latitude: 17.897728,
+      longitude: -62.834244,
+    },
+  ],
+  [
+    "SH",
+    {
+      latitude: -15.9333,
+      longitude: -5.7,
+    },
+  ],
+  [
+    "KN",
+    {
+      latitude: 17.3333,
+      longitude: -62.75,
+    },
+  ],
+  [
+    "LC",
+    {
+      latitude: 13.8833,
+      longitude: -61.1333,
+    },
+  ],
+  [
+    "MF",
+    {
+      latitude: 18.075278,
+      longitude: -63.06,
+    },
+  ],
+  [
+    "PM",
+    {
+      latitude: 46.8333,
+      longitude: -56.3333,
+    },
+  ],
+  [
+    "VC",
+    {
+      latitude: 13.25,
+      longitude: -61.2,
+    },
+  ],
+  [
+    "WS",
+    {
+      latitude: -13.5833,
+      longitude: -172.3333,
+    },
+  ],
+  [
+    "SM",
+    {
+      latitude: 43.7667,
+      longitude: 12.4167,
+    },
+  ],
+  [
+    "ST",
+    {
+      latitude: 1,
+      longitude: 7,
+    },
+  ],
+  [
+    "SA",
+    {
+      latitude: 25,
+      longitude: 45,
+    },
+  ],
+  [
+    "SN",
+    {
+      latitude: 14,
+      longitude: -14,
+    },
+  ],
+  [
+    "RS",
+    {
+      latitude: 44,
+      longitude: 21,
+    },
+  ],
+  [
+    "SC",
+    {
+      latitude: -4.5833,
+      longitude: 55.6667,
+    },
+  ],
+  [
+    "SL",
+    {
+      latitude: 8.5,
+      longitude: -11.5,
+    },
+  ],
+  [
+    "SG",
+    {
+      latitude: 1.3667,
+      longitude: 103.8,
+    },
+  ],
+  [
+    "SX",
+    {
+      latitude: 18.033333,
+      longitude: -63.05,
+    },
+  ],
+  [
+    "SK",
+    {
+      latitude: 48.6667,
+      longitude: 19.5,
+    },
+  ],
+  [
+    "SI",
+    {
+      latitude: 46,
+      longitude: 15,
+    },
+  ],
+  [
+    "SB",
+    {
+      latitude: -8,
+      longitude: 159,
+    },
+  ],
+  [
+    "SO",
+    {
+      latitude: 10,
+      longitude: 49,
+    },
+  ],
+  [
+    "ZA",
+    {
+      latitude: -29,
+      longitude: 24,
+    },
+  ],
+  [
+    "GS",
+    {
+      latitude: -54.5,
+      longitude: -37,
+    },
+  ],
+  [
+    "KR",
+    {
+      latitude: 37,
+      longitude: 127.5,
+    },
+  ],
+  [
+    "SS",
+    {
+      latitude: 8,
+      longitude: 30,
+    },
+  ],
+  [
+    "ES",
+    {
+      latitude: 40,
+      longitude: -4,
+    },
+  ],
+  [
+    "LK",
+    {
+      latitude: 7,
+      longitude: 81,
+    },
+  ],
+  [
+    "SD",
+    {
+      latitude: 15,
+      longitude: 30,
+    },
+  ],
+  [
+    "SR",
+    {
+      latitude: 4,
+      longitude: -56,
+    },
+  ],
+  [
+    "SJ",
+    {
+      latitude: 78,
+      longitude: 20,
+    },
+  ],
+  [
+    "SZ",
+    {
+      latitude: -26.5,
+      longitude: 31.5,
+    },
+  ],
+  [
+    "SE",
+    {
+      latitude: 62,
+      longitude: 15,
+    },
+  ],
+  [
+    "CH",
+    {
+      latitude: 47,
+      longitude: 8,
+    },
+  ],
+  [
+    "SY",
+    {
+      latitude: 35,
+      longitude: 38,
+    },
+  ],
+  [
+    "TW",
+    {
+      latitude: 23.5,
+      longitude: 121,
+    },
+  ],
+  [
+    "TJ",
+    {
+      latitude: 39,
+      longitude: 71,
+    },
+  ],
+  [
+    "TZ",
+    {
+      latitude: -6,
+      longitude: 35,
+    },
+  ],
+  [
+    "TH",
+    {
+      latitude: 15,
+      longitude: 100,
+    },
+  ],
+  [
+    "TL",
+    {
+      latitude: -8.55,
+      longitude: 125.5167,
+    },
+  ],
+  [
+    "TG",
+    {
+      latitude: 8,
+      longitude: 1.1667,
+    },
+  ],
+  [
+    "TK",
+    {
+      latitude: -9,
+      longitude: -172,
+    },
+  ],
+  [
+    "TO",
+    {
+      latitude: -20,
+      longitude: -175,
+    },
+  ],
+  [
+    "TT",
+    {
+      latitude: 11,
+      longitude: -61,
+    },
+  ],
+  [
+    "TN",
+    {
+      latitude: 34,
+      longitude: 9,
+    },
+  ],
+  [
+    "TR",
+    {
+      latitude: 39,
+      longitude: 35,
+    },
+  ],
+  [
+    "TM",
+    {
+      latitude: 40,
+      longitude: 60,
+    },
+  ],
+  [
+    "TC",
+    {
+      latitude: 21.75,
+      longitude: -71.5833,
+    },
+  ],
+  [
+    "TV",
+    {
+      latitude: -8,
+      longitude: 178,
+    },
+  ],
+  [
+    "UG",
+    {
+      latitude: 1,
+      longitude: 32,
+    },
+  ],
+  [
+    "UA",
+    {
+      latitude: 49,
+      longitude: 32,
+    },
+  ],
+  [
+    "AE",
+    {
+      latitude: 24,
+      longitude: 54,
+    },
+  ],
+  [
+    "GB",
+    {
+      latitude: 54,
+      longitude: -2,
+    },
+  ],
+  [
+    "UM",
+    {
+      latitude: 19.2833,
+      longitude: 166.6,
+    },
+  ],
+  [
+    "US",
+    {
+      latitude: 38,
+      longitude: -97,
+    },
+  ],
+  [
+    "UY",
+    {
+      latitude: -33,
+      longitude: -56,
+    },
+  ],
+  [
+    "UZ",
+    {
+      latitude: 41,
+      longitude: 64,
+    },
+  ],
+  [
+    "VU",
+    {
+      latitude: -16,
+      longitude: 167,
+    },
+  ],
+  [
+    "VE",
+    {
+      latitude: 8,
+      longitude: -66,
+    },
+  ],
+  [
+    "VN",
+    {
+      latitude: 16,
+      longitude: 106,
+    },
+  ],
+  [
+    "VG",
+    {
+      latitude: 18.5,
+      longitude: -64.5,
+    },
+  ],
+  [
+    "VI",
+    {
+      latitude: 18.3333,
+      longitude: -64.8333,
+    },
+  ],
+  [
+    "WF",
+    {
+      latitude: -13.3,
+      longitude: -176.2,
+    },
+  ],
+  [
+    "EH",
+    {
+      latitude: 24.5,
+      longitude: -13,
+    },
+  ],
+  [
+    "YE",
+    {
+      latitude: 15,
+      longitude: 48,
+    },
+  ],
+  [
+    "ZM",
+    {
+      latitude: -15,
+      longitude: 30,
+    },
+  ],
+  [
+    "ZW",
+    {
+      latitude: -20,
+      longitude: 30,
+    },
+  ],
+])

--- a/frontend/src/features/map/components/Map/Map.tsx
+++ b/frontend/src/features/map/components/Map/Map.tsx
@@ -3,11 +3,13 @@ import "leaflet/dist/leaflet.css"
 import L from "leaflet"
 import { useEffect, useState } from "react"
 import { createPortal } from "react-dom"
+import { Station } from "../../../../api/radiobrowser/types"
+import RadioCard from "../RadioCard/RadioCard"
 
 let map: L.Map
 
 type MapProps = {
-  popupContent: JSX.Element | null
+  station: Station | null
 }
 
 function Map(props: MapProps) {
@@ -20,7 +22,7 @@ function Map(props: MapProps) {
     }
   }, [])
   useEffect(() => {
-    if (props.popupContent == null) {
+    if (props.station == null) {
       return
     }
     const popupDiv = document.createElement("div")
@@ -32,12 +34,12 @@ function Map(props: MapProps) {
     return () => {
       popup.remove()
     }
-  }, [setPopupContainer, props.popupContent])
+  }, [setPopupContainer, props.station])
   return (
     <div id="map">
       {popupContainer !== null &&
-        props.popupContent &&
-        createPortal(props.popupContent, popupContainer)}
+        props.station &&
+        createPortal(<RadioCard station={props.station} />, popupContainer)}
     </div>
   )
 }

--- a/frontend/src/features/map/components/Map/Map.tsx
+++ b/frontend/src/features/map/components/Map/Map.tsx
@@ -32,6 +32,7 @@ function Map(props: MapProps) {
       .setContent(popupDiv)
       .openOn(map)
     setPopupContainer(popupDiv)
+    map.panTo(location, { animate: true })
     return () => {
       popup.remove()
     }

--- a/frontend/src/features/map/components/Map/Map.tsx
+++ b/frontend/src/features/map/components/Map/Map.tsx
@@ -25,9 +25,10 @@ function Map(props: MapProps) {
     if (props.station == null) {
       return
     }
+    const location = getStationLocation(props.station)
     const popupDiv = document.createElement("div")
     const popup = L.popup({ minWidth: 300, keepInView: true })
-      .setLatLng([1.35, 103.81]) // TODO fix hard coded position
+      .setLatLng(location)
       .setContent(popupDiv)
       .openOn(map)
     setPopupContainer(popupDiv)
@@ -53,6 +54,15 @@ function setupMap() {
       '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   }).addTo(map)
   return map
+}
+
+function getStationLocation(station: Station) {
+  if (station.geo_lat && station.geo_long) {
+    return { lat: station.geo_lat, lng: station.geo_long }
+  } else {
+    console.error("Could not get coordinates for station: ", station.name)
+    return { lat: 1.35, lng: 103.81 }
+  }
 }
 
 export default Map


### PR DESCRIPTION
Currently, only considering the `countrycode` (ISO 3166-1 Alpha-2 code). **Not taking into consideration the `state`**
- Show approximate location for country if the `geo_lat` and `geo_long` of the station information is not available (`null`)
- Update the station information during the call to get the random station. Use an existing `Map` consisting of `countrycode` => `{ longitude: number, latitude: number}`

Countries with their (ISO 3166-1) Alpha-2 code, Alpha-3 code, UN M49, average latitude and longitude coordinates - https://gist.github.com/tadast/8827699

https://leafletjs.com/reference.html#map-event
