### PR TITLE
Update AAC codec to include application/x-mpegURL

### DIFF
--- a/frontend/src/features/map/components/RadioCard/RadioCard.tsx
+++ b/frontend/src/features/map/components/RadioCard/RadioCard.tsx
@@ -71,8 +71,8 @@ function RadioCard(props: RadioCardProps) {
 function getAudioSources(station: Station) {
   // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers
   const codecToType = new Map([
-    ["AAC", ["audio/aac", "audio/x-mpegURL"]],
-    ["AAC+", ["audio/aac", "audio/x-mpegURL"]],
+    ["AAC", ["audio/aac", "audio/x-mpegurl", "application/x-mpegURL"]],
+    ["AAC+", ["audio/aac", "audio/x-mpegurl", "application/x-mpegURL"]],
     ["OGG", ["audio/ogg"]],
     ["MP3", ["audio/mpeg"]],
   ])
@@ -101,7 +101,11 @@ function getAudioSources(station: Station) {
     },
     {
       src: station.url_resolved,
-      type: "audio/x-mpegURL",
+      type: "audio/x-mpegurl",
+    },
+    {
+      src: station.url_resolved,
+      type: "application/x-mpegURL",
     },
   ]
 }


### PR DESCRIPTION
Example error in browser

HTTP “Content-Type” of “application/vnd.apple.mpegurl” is not supported. Load of media resource https://radio357.s3.eu-central-1.amazonaws.com/stream/29ce0221-3d37-47d9-97b9-559cfad16ed3.m3u8 failed.

VIDEOJS: ERROR: (CODE:4 MEDIA_ERR_SRC_NOT_SUPPORTED) The media could not be loaded, either because the server or network failed or because the format is not supported. 
Object { code: 4, message: "The media could not be loaded, either because the server or network failed or because the format is not supported." }