### PR TITLE
Prevent random radio station button click for at least 3 seconds after click

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
     } else {
       toast.error("Could not get random radio station")
     }
-    setIsLoading(false)
+    setTimeout(() => setIsLoading(false), 3000)
   }
   return (
     <>

--- a/frontend/src/api/radiobrowser/servers.ts
+++ b/frontend/src/api/radiobrowser/servers.ts
@@ -2,7 +2,7 @@
 // http://all.api.radio-browser.info/json/servers
 const servers: string[] = [
   "https://nl1.api.radio-browser.info",
-  "https://de1.api.radio-browser.info",
+  // "https://de1.api.radio-browser.info", // HTTP 502 Errors
   "https://at1.api.radio-browser.info",
 ]
 const serverCount = servers.length

--- a/frontend/src/features/radioselect/components/RadioSelect/RadioSelect.css
+++ b/frontend/src/features/radioselect/components/RadioSelect/RadioSelect.css
@@ -16,3 +16,7 @@
 .radio-select-random-btn:hover {
   filter: brightness(0.9);
 }
+.radio-select-random-btn:disabled {
+  background-color: var(--disabled-element-color);
+  pointer-events: none;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,6 +93,7 @@ button:focus-visible {
     --error-color: #a80b0b;
     --success-color: #0e5d3c;
     --link-color: #293a6f;
+    --disabled-element-color: #737373;
     background-color: var(--background-color);
     color: var(--text-color);
   }
@@ -109,6 +110,7 @@ button:focus-visible {
     --error-color: #ff3535;
     --success-color: #22c55e;
     --link-color: #e6f0f7;
+    --disabled-element-color: #737373;
     background-color: var(--background-color);
     color: var(--text-color);
   }


### PR DESCRIPTION
Set isLoading state to false using `setTimeout` of 3000ms (3 seconds)

This happens after data fetch of a random radio station. So after clicking the get random station button, the user needs to wait at least 3 seconds before the button is enabled again. (The button remains disabled as long as `isLoading` state is set to true)