### PR TITLE
Add header toggle for light / dark mode toggle

### DIFF
--- a/frontend/src/components/Header/Header.css
+++ b/frontend/src/components/Header/Header.css
@@ -13,3 +13,10 @@ header {
   font-weight: bold;
   padding: 0;
 }
+
+.header-info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,10 +1,14 @@
+import ThemeToggle from "../ThemeToggle/ThemeToggle"
 import "./Header.css"
 
 function Header() {
   return (
     <header>
       <p className="header-app-name">Xtal</p>
-      <p>Listen to the World</p>
+      <div className="header-info">
+        <p>Listen to the World</p>
+        <ThemeToggle />
+      </div>
     </header>
   )
 }

--- a/frontend/src/components/ThemeToggle/ThemeToggle.css
+++ b/frontend/src/components/ThemeToggle/ThemeToggle.css
@@ -1,0 +1,8 @@
+.theme-toggle-btn {
+  display: grid;
+  place-items: center;
+  border-radius: 25%;
+  aspect-ratio: 1;
+  padding: 0.3rem;
+  background-color: var(--secondary-color);
+}

--- a/frontend/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+import { useContext } from "react"
+import { FaMoon, FaSun } from "react-icons/fa"
+import "./ThemeToggle.css"
+import { ThemeContext } from "../../context/ThemeProvider/ThemeProvider"
+
+function ThemeToggle() {
+  const theme = useContext(ThemeContext)
+  return theme == undefined ? null : (
+    <button
+      onClick={() => theme.toggle()}
+      className="theme-toggle-btn"
+      data-testid="theme-toggle-btn"
+      title="Toggle Theme"
+    >
+      {theme?.isDark ? (
+        <FaMoon className="dark-mode-icon" size={24} />
+      ) : (
+        <FaSun className="light-mode-icon" size={24} />
+      )}
+    </button>
+  )
+}
+
+export default ThemeToggle

--- a/frontend/src/context/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/context/ThemeProvider/ThemeProvider.tsx
@@ -38,7 +38,7 @@ type Theme = {
   isDark: boolean
   toggle: () => void
 }
-const ThemeContext = createContext<Theme | undefined>(undefined)
+export const ThemeContext = createContext<Theme | undefined>(undefined)
 
 // https://stackoverflow.com/questions/61117608/how-do-i-set-system-preference-dark-mode-in-a-react-app-but-also-allow-users-to
 function ThemeProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/context/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/context/ThemeProvider/ThemeProvider.tsx
@@ -51,8 +51,6 @@ function ThemeProvider({ children }: { children: React.ReactNode }) {
     root.style.cssText = theme.join("")
   }
   function toggle() {
-    const body = document.getElementsByTagName("body")[0]
-    body.style.cssText = "transition: background 0.3s"
     const theme = isDark ? lightTheme : darkTheme
     applyTheme(theme)
     setIsDark(!isDark)

--- a/frontend/src/context/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/context/ThemeProvider/ThemeProvider.tsx
@@ -38,6 +38,7 @@ type Theme = {
   isDark: boolean
   toggle: () => void
 }
+// eslint-disable-next-line react-refresh/only-export-components
 export const ThemeContext = createContext<Theme | undefined>(undefined)
 
 // https://stackoverflow.com/questions/61117608/how-do-i-set-system-preference-dark-mode-in-a-react-app-but-also-allow-users-to

--- a/frontend/src/context/ThemeProvider/ThemeProvider.tsx
+++ b/frontend/src/context/ThemeProvider/ThemeProvider.tsx
@@ -1,0 +1,68 @@
+import { createContext, useState } from "react"
+
+// https://www.realtimecolors.com/?colors=180c15-fdfafc-fdacca-9fcd9b-e45ac2&fonts=Ubuntu-Ubuntu
+const lightTheme = [
+  "--text-color: #180c15;",
+  "--background-color: #fdfafc;",
+  "--primary-color: #fdacca;",
+  "--secondary-color: #9fcd9b;",
+  "--accent-color: #e45ac2;",
+  "--error-color: #a80b0b;",
+  "--success-color: #0e5d3c;",
+  "--link-color: #0b2881;",
+  "--disabled-element-color: #737373;",
+  "--genre-chip-primary-color: #d4d4d4;",
+  "--genre-chip-secondary-color: #e5e5e5;",
+  "--genre-chip-selected-color: #262626;",
+  "--genre-chip-selected-text-color: #f5f5f5;",
+]
+
+// https://www.realtimecolors.com/?colors=e8ebf5-0b0f1d-4846b6-143fc0-3059d2&fonts=Ubuntu-Ubuntu
+const darkTheme = [
+  "--text-color: #e8ebf5;",
+  "--background-color: #0b0f1d;",
+  "--primary-color: #4846b6;",
+  "--secondary-color: #143fc0;",
+  "--accent-color: #3059d2;",
+  "--error-color: #ff3535;",
+  "--success-color: #22c55e;",
+  "--link-color: #e6f0f7;",
+  "--disabled-element-color: #737373;",
+  "--genre-chip-primary-color: #525252;",
+  "--genre-chip-secondary-color: #737373;",
+  "--genre-chip-selected-color: #d4d4d4;",
+  "--genre-chip-selected-text-color: #171717;",
+]
+
+type Theme = {
+  isDark: boolean
+  toggle: () => void
+}
+const ThemeContext = createContext<Theme | undefined>(undefined)
+
+// https://stackoverflow.com/questions/61117608/how-do-i-set-system-preference-dark-mode-in-a-react-app-but-also-allow-users-to
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [isDark, setIsDark] = useState<boolean>(
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  )
+  function applyTheme(theme: string[]) {
+    const root = document.getElementsByTagName("html")[0]
+    root.style.cssText = theme.join("")
+  }
+  function toggle() {
+    const body = document.getElementsByTagName("body")[0]
+    body.style.cssText = "transition: background 0.3s"
+    const theme = isDark ? lightTheme : darkTheme
+    applyTheme(theme)
+    setIsDark(!isDark)
+  }
+
+  applyTheme(isDark ? darkTheme : lightTheme)
+  return (
+    <ThemeContext.Provider value={{ isDark, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export default ThemeProvider

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,6 +42,8 @@
   flex-direction: column;
   width: 100%;
   min-height: 100vh;
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 main {
@@ -86,46 +88,4 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    /* https://www.realtimecolors.com/?colors=180c15-fdfafc-fdacca-9fcd9b-e45ac2&fonts=Ubuntu-Ubuntu */
-    --text-color: #180c15;
-    --background-color: #fdfafc;
-    --primary-color: #fdacca;
-    --secondary-color: #9fcd9b;
-    --accent-color: #e45ac2;
-    --error-color: #a80b0b;
-    --success-color: #0e5d3c;
-    --link-color: #0b2881;
-    --disabled-element-color: #737373;
-    --genre-chip-primary-color: #d4d4d4;
-    --genre-chip-secondary-color: #e5e5e5;
-    --genre-chip-selected-color: #262626;
-    --genre-chip-selected-text-color: #f5f5f5;
-    background-color: var(--background-color);
-    color: var(--text-color);
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    /* https://www.realtimecolors.com/?colors=e8ebf5-0b0f1d-4846b6-143fc0-3059d2&fonts=Ubuntu-Ubuntu */
-    --text-color: #e8ebf5;
-    --background-color: #0b0f1d;
-    --primary-color: #4846b6;
-    --secondary-color: #143fc0;
-    --accent-color: #3059d2;
-    --error-color: #ff3535;
-    --success-color: #22c55e;
-    --link-color: #e6f0f7;
-    --disabled-element-color: #737373;
-    --genre-chip-primary-color: #525252;
-    --genre-chip-secondary-color: #737373;
-    --genre-chip-selected-color: #d4d4d4;
-    --genre-chip-selected-text-color: #171717;
-    background-color: var(--background-color);
-    color: var(--text-color);
-  }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import "./index.css"
 import App from "./App.tsx"
+import ThemeProvider from "./context/ThemeProvider/ThemeProvider.tsx"
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 )

--- a/frontend/tests/constants.ts
+++ b/frontend/tests/constants.ts
@@ -1,0 +1,1 @@
+export const HOMEPAGE = "http://localhost:5173"

--- a/frontend/tests/homepage.app.theme.spec.ts
+++ b/frontend/tests/homepage.app.theme.spec.ts
@@ -1,0 +1,26 @@
+import test, { expect, Page } from "@playwright/test"
+import { HOMEPAGE } from "./constants"
+
+// https://playwright.dev/docs/emulation#color-scheme-and-media
+test.use({
+  colorScheme: "dark",
+})
+
+test.describe("header app theme (start with dark mode)", () => {
+  function getDarkModeIcon(page: Page) {
+    return page.getByTestId("theme-toggle-btn").locator(".dark-mode-icon")
+  }
+  function getLightModeIcon(page: Page) {
+    return page.getByTestId("theme-toggle-btn").locator(".light-mode-icon")
+  }
+
+  test("should switch theme when app theme button is clicked", async ({
+    page,
+  }) => {
+    await page.goto(HOMEPAGE)
+    await expect(getDarkModeIcon(page)).toBeVisible()
+    await page.getByTestId("theme-toggle-btn").click()
+    await expect(getLightModeIcon(page)).toBeVisible()
+    await expect(getDarkModeIcon(page)).not.toBeVisible()
+  })
+})

--- a/frontend/tests/homepage.spec.ts
+++ b/frontend/tests/homepage.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect, Page } from "@playwright/test"
+import { HOMEPAGE } from "./constants"
 import {
   stationWithBlockedAccess,
   stationWithMultipleTags,
   stationWithNoLocationLatLng,
 } from "./mocks/station"
-
-const HOMEPAGE = "http://localhost:5173"
 
 async function clickRandomRadioStationButton(page: Page) {
   await page.getByTestId("random-radio-station-btn").click()


### PR DESCRIPTION
Use React Context to set the CSS variables for the light / dark mode theme in the `<html>` element
Created custom context/ThemeProvider for component to toggle theme

Reads user preference from `window.matchMedia("(prefers-color-scheme: dark)").matches`
- https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia

DOES NOT WORK => `transition: background 0.3s` on `<body>`

![image](https://github.com/user-attachments/assets/a610ca4b-7909-46f3-bb19-ee5aa960d2c9)

![image](https://github.com/user-attachments/assets/4b0bd98b-fd9d-4c88-a221-1db2b8962422)
