### PR TITLE
Fix station offset remaining the same on next random station button click

### DIFF
--- a/frontend/src/api/radiobrowser/searchStrategy/CountryStationSearchStrategy.ts
+++ b/frontend/src/api/radiobrowser/searchStrategy/CountryStationSearchStrategy.ts
@@ -5,21 +5,23 @@ import { getRandomServer } from "../servers"
 import { getStation } from "../station"
 
 export class CountryStationSearchStrategy implements StationSearchStrategy {
-  private searchParams: URLSearchParams
+  private country: CountryStation
 
   constructor(country: CountryStation) {
-    const countryCode = country.countryCode
-    const offset = this.getRandomInt(country.stationCount)
-    const limit = 3
-    this.searchParams = new URLSearchParams(
-      `?countrycode=${countryCode}&order=random&limit=${limit}&offset=${offset}`
-    )
+    this.country = country
   }
 
   async findStation(abortController: AbortController): Promise<Station | null> {
+    // offset needs to be different for each call of findStation
+    const offset = this.getRandomInt(this.country.stationCount)
+    const countryCode = this.country.countryCode
+    const limit = 3
+    const searchParams = new URLSearchParams(
+      `countrycode=${countryCode}&order=random&limit=${limit}&offset=${offset}`
+    )
     const server = await getRandomServer()
     const url = `${server}/json/stations/search`
-    return await getStation(abortController, url, this.searchParams)
+    return await getStation(abortController, url, searchParams)
   }
 
   getRandomInt(max: number) {

--- a/frontend/src/api/radiobrowser/searchStrategy/GenreStationSearchStrategy.ts
+++ b/frontend/src/api/radiobrowser/searchStrategy/GenreStationSearchStrategy.ts
@@ -5,21 +5,25 @@ import { Station } from "../types"
 import { StationSearchStrategy } from "./StationSearchStrategy"
 
 export class GenreStationSearchStrategy implements StationSearchStrategy {
-  private searchParams: URLSearchParams
+  private genre: GenreInformation
 
   constructor(genre: GenreInformation) {
-    const tag = genre.searchTag
-    const offset = this.getRandomInt(genre.approxStationCount)
-    const limit = 3
-    this.searchParams = new URLSearchParams(
-      `?order=random&limit=${limit}&hidebroken=true&is_https=true&offset=${offset}&tag=${tag}`
-    )
+    this.genre = genre
   }
 
   async findStation(abortController: AbortController): Promise<Station | null> {
+    // offset needs to be different for each call
+    const offset = this.getRandomInt(this.genre.approxStationCount)
+    const tag = this.genre.searchTag
+    const limit = 3
+    const searchParams = new URLSearchParams(
+      tag !== ""
+        ? `order=random&limit=${limit}&hidebroken=true&is_https=true&offset=${offset}&tag=${tag}`
+        : `order=random&limit=${limit}&hidebroken=true&is_https=true&offset=${offset}`
+    )
     const server = await getRandomServer()
     const url = `${server}/json/stations/search`
-    return await getStation(abortController, url, this.searchParams)
+    return await getStation(abortController, url, searchParams)
   }
 
   getRandomInt(max: number) {

--- a/frontend/tests/homepage.spec.ts
+++ b/frontend/tests/homepage.spec.ts
@@ -334,4 +334,23 @@ test.describe("radio station search type", () => {
     )
     expect(offsets.size).toBe(2)
   })
+
+  test("second random genre station request should call API with different offset number", async ({
+    page,
+  }) => {
+    const apiCalls: string[] = []
+    await page.route("*/**/json/stations/search?*", async (route) => {
+      apiCalls.push(route.request().url())
+      const json = [stationWithMultipleTags]
+      await route.fulfill({ json })
+    })
+    await page.goto(HOMEPAGE)
+    await getGenreSearchButton(page).click()
+    await clickRandomRadioStationButton(page)
+    await clickRandomRadioStationButton(page)
+    const offsets = new Set(
+      apiCalls.map((apiCall) => new URLSearchParams(apiCall).get("offset"))
+    )
+    expect(offsets.size).toBe(2)
+  })
 })

--- a/frontend/tests/homepage.spec.ts
+++ b/frontend/tests/homepage.spec.ts
@@ -311,4 +311,27 @@ test.describe("radio station search type", () => {
       })
     ).toBeVisible()
   })
+
+  test("second random country station request should call API with different offset number", async ({
+    page,
+  }) => {
+    const apiCalls: string[] = []
+    const expectedCountryCode = "US"
+    await page.route(
+      `*/**/json/stations/search?countrycode=${expectedCountryCode}&*`,
+      async (route) => {
+        apiCalls.push(route.request().url())
+        const json = [unitedStatesStation]
+        await route.fulfill({ json })
+      }
+    )
+    await page.goto(HOMEPAGE)
+    await getCountrySearchButton(page).click()
+    await clickRandomRadioStationButton(page)
+    await clickRandomRadioStationButton(page)
+    const offsets = new Set(
+      apiCalls.map((apiCall) => new URLSearchParams(apiCall).get("offset"))
+    )
+    expect(offsets.size).toBe(2)
+  })
 })


### PR DESCRIPTION
The station offset calculated should not be placed in the constructor, as subsequent attempts to get new random radio stations are using the same offset.

The offset should be generated dynamically on each function call to get a new random radio station