### PR TITLE
Fix incorrect render of 0 for bitrate based on conditional rendering

### DIFF
--- a/frontend/src/features/map/components/RadioCard/RadioCard.tsx
+++ b/frontend/src/features/map/components/RadioCard/RadioCard.tsx
@@ -45,7 +45,7 @@ function RadioCard(props: RadioCardProps) {
     <div className="radio-card">
       {station.favicon && <img src={station.favicon} height={64} width={64} />}
       <h2 className="station-name">{station.name}</h2>
-      {station.bitrate && (
+      {station.bitrate > 0 && (
         <Pill key="station-bitrate">{station.bitrate} kbps</Pill>
       )}
       {station.tags && (


### PR DESCRIPTION
https://react.dev/learn/conditional-rendering#logical-and-operator-

A [JavaScript && expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) returns the value of its right side (in our case, the checkmark) if the left side (our condition) is true. But if the condition is false, the whole expression becomes false. React considers false as a “hole” in the JSX tree, just like null or undefined, and doesn’t render anything in its place.

### Pitfall
**Don’t put numbers on the left side of &&.**

To test the condition, JavaScript converts the left side to a boolean automatically. However, if the left side is 0, then the whole expression gets that value (0), and React will happily render 0 rather than nothing.

For example, a common mistake is to write code like `messageCount && <p>New messages</p>`. It’s easy to assume that it renders nothing when messageCount is 0, but it really renders the 0 itself!

To fix it, make the left side a boolean: `messageCount > 0 && <p>New messages</p>`.

![image](https://github.com/user-attachments/assets/7191d740-ca90-4468-a665-59c3dc7c26dc)