### PR TITLE
Add station card placeholder icon for empty favicon

### DIFF
--- a/frontend/src/components/StationCard/StationCard.tsx
+++ b/frontend/src/components/StationCard/StationCard.tsx
@@ -6,6 +6,7 @@ import { FaMapMarkerAlt } from "react-icons/fa"
 import { BiSolidLike } from "react-icons/bi"
 import { IoLanguageSharp } from "react-icons/io5"
 import { GoStar, GoStarFill } from "react-icons/go"
+import { MdOutlineImageNotSupported } from "react-icons/md"
 
 type StationCardContext = {
   station: Station
@@ -35,15 +36,19 @@ export default function StationCard({ children, station }: StationCardProps) {
 
 StationCard.Icon = function StationCardIcon() {
   const { station } = useStationCardContext()
-  return (
-    station.favicon && (
-      <img
-        className="station-card-icon"
-        src={station.favicon}
-        height={64}
-        width={64}
-      />
-    )
+  return station.favicon ? (
+    <img
+      className="station-card-icon"
+      src={station.favicon}
+      height={64}
+      width={64}
+    />
+  ) : (
+    <MdOutlineImageNotSupported
+      className="station-card-icon"
+      size={64}
+      title="Icon Not Available"
+    />
   )
 }
 

--- a/frontend/tests/homepage.favourite.station.spec.ts
+++ b/frontend/tests/homepage.favourite.station.spec.ts
@@ -201,4 +201,27 @@ test.describe("radio station favourite feature", () => {
       })
     ).toBeVisible()
   })
+
+  test("placeholder icon shows up for station with empty favicon", async ({
+    page,
+  }) => {
+    await page.route("*/**/json/stations/search?*", async (route) => {
+      const json = [{ ...unitedStatesStation, favicon: "" }]
+      await route.fulfill({ json })
+    })
+    await page.goto(HOMEPAGE)
+    await clickRandomRadioStationButton(page)
+    await getRadioCardFavouriteButton(page).click()
+    await expect(
+      page.locator("#map .radio-card .station-card-icon")
+    ).toBeVisible()
+    // open the favourite station drawer, and assert placeholder icon is shown
+    await getFavouriteStationsButton(page).click()
+    await expect(
+      getFavouriteStationsDrawer(page).locator(".station-card-icon")
+    ).toBeVisible()
+    await expect(
+      getFavouriteStationsDrawer(page).locator(".station-card-icon title")
+    ).toHaveText("Icon Not Available")
+  })
 })


### PR DESCRIPTION
Use React Icons - MdOutlineImageNotSupported
https://react-icons.github.io/react-icons/search/#q=MdOutlineImageNotSupported

![image](https://github.com/user-attachments/assets/27878893-c939-430d-b70a-b572dbab068d)

![image](https://github.com/user-attachments/assets/49a40a0c-09cc-481b-af9e-49c0c9fb081b)

![image](https://github.com/user-attachments/assets/e91729f9-f56e-4173-b50e-c17b6b96959b)