### PR TITLE
Add favourite station limit

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,17 +5,7 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  create-envfile:
-    defaults:
-      run:
-        working-directory: frontend
-    runs-on: ubuntu-latest
-    steps:
-      - name: Make envfile
-        run: |
-          echo "VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS=${{ secrets.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS }}" >> .env.local
   test:
-    needs: create-envfile
     timeout-minutes: 60
     defaults:
       run:
@@ -26,6 +16,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+      - name: Create envfile
+        run: |
+          echo "VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS=${{ secrets.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS }}" >> .env.local
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,20 @@ on:
   pull_request:
     branches: [main]
 jobs:
+  create-envfile:
+    defaults:
+      run:
+        working-directory: frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make envfile
+        uses: SpicyPizza/create-envfile@v2.0
+        with:
+          envkey_VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS: ${{ secrets.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS }}
+          directory: frontend
+          file_name: .env.local
   test:
+    needs: create-envfile
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,11 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Make envfile
-        uses: SpicyPizza/create-envfile@v2.0
-        with:
-          envkey_VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS: ${{ secrets.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS }}
-          directory: frontend
-          file_name: .env.local
+        run: |
+          echo "VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS=${{ secrets.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS }}" >> .env.local
   test:
     needs: create-envfile
     timeout-minutes: 60

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.env
+.env.production
 *.local
 
 # Editor directories and files

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,18 @@
 
 Made using TypeScript, React and Playwright (testing)
 
+# Setup
+
+1. Create a `.env.production` and `.env.local` file - https://vite.dev/guide/env-and-mode#env-files
+
+   - e.g. `.env.local`
+
+   ```
+   VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS=3
+   ```
+
+2. On the GitHub Actions secrets, add each environment property defined in`.github/workflows/playwright.yml` that contains the env file used for QA (testing) `.env.local`
+
 # Packages used
 
 - Radio Browser - https://www.radio-browser.info/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "dotenv": "16.4.7",
         "ky": "1.7.4",
         "leaflet": "1.9.4",
         "motion": "11.17.0",
@@ -2016,6 +2017,18 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.62",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,13 +4,15 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --mode development",
+    "prod": "vite --mode production",
     "test": "npx playwright test --ui --headed",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build --mode production",
     "lint": "eslint .",
     "preview": "vite preview"
   },
   "dependencies": {
+    "dotenv": "16.4.7",
     "ky": "1.7.4",
     "leaflet": "1.9.4",
     "motion": "11.17.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,9 +4,14 @@ import { defineConfig, devices } from "@playwright/test"
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+import dotenv from "dotenv"
+import path from "path"
+import { fileURLToPath } from "url"
+// https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d
+const __filename = fileURLToPath(import.meta.url) // get the resolved path to the file
+const __dirname = path.dirname(__filename) // get the name of the directory
+
+dotenv.config({ path: path.resolve(__dirname, ".env.local") })
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,14 @@ function App() {
   }
   return (
     <>
-      <Toaster position="bottom-right" expand={true} richColors />
+      <Toaster
+        position="bottom-right"
+        expand={true}
+        richColors
+        toastOptions={{
+          className: "toaster",
+        }}
+      />
       <Header />
       <main>
         <RadioSelect

--- a/frontend/tests/constants/favouriteStationConstants.ts
+++ b/frontend/tests/constants/favouriteStationConstants.ts
@@ -11,3 +11,7 @@ export function getFavouriteStationsDrawer(page: Page) {
 export async function closeFavouriteStationsDrawer(page: Page) {
   await page.locator(".drawer-close-button").click()
 }
+
+export function getRadioCardFavouriteIcon(page: Page) {
+  return page.locator("#map .radio-card .station-card-favourite-icon")
+}

--- a/frontend/tests/constants/homepageConstants.ts
+++ b/frontend/tests/constants/homepageConstants.ts
@@ -1,9 +1,9 @@
-import { Page } from "@playwright/test"
+import { expect, Page } from "@playwright/test"
 
 export const HOMEPAGE = "http://localhost:5173"
 
 export async function clickRandomRadioStationButton(page: Page) {
-  await page.getByTestId("random-radio-station-btn").isEnabled()
+  await expect(page.getByTestId("random-radio-station-btn")).toBeEnabled()
   await page.getByTestId("random-radio-station-btn").click()
 }
 

--- a/frontend/tests/homepage.favourite.station.limit.spec.ts
+++ b/frontend/tests/homepage.favourite.station.limit.spec.ts
@@ -1,0 +1,73 @@
+import test, { expect, Page } from "@playwright/test"
+import process from "process"
+import { unitedStatesStation } from "./mocks/station"
+import {
+  clickRandomRadioStationButton,
+  HOMEPAGE,
+} from "./constants/homepageConstants"
+import { getRadioCardFavouriteIcon } from "./constants/favouriteStationConstants"
+
+test.describe("radio station favourite station limit feature", () => {
+  function uuid() {
+    return crypto.randomUUID()
+  }
+  async function assertToastMessage(page: Page, message: string) {
+    const toasts = await page.locator(".toaster").all()
+    const toastMessages = (
+      await Promise.all(toasts.map((locator) => locator.allTextContents()))
+    ).flat(1)
+    expect(toastMessages).toEqual(expect.arrayContaining([message]))
+  }
+
+  test("should show warning toast when total favourite stations limit is reached", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000)
+    const MAX_FAVOURITE_STATIONS = 3
+    expect(
+      process.env.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS,
+      ".env.local environment property VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS should be defined"
+    ).toBe(`${MAX_FAVOURITE_STATIONS}`)
+    await page.route("*/**/json/stations/search?*", async (route) => {
+      const json = [{ ...unitedStatesStation, stationuuid: uuid() }]
+      await route.fulfill({ json })
+    })
+    await page.goto(HOMEPAGE)
+    for (let i = 0; i < MAX_FAVOURITE_STATIONS - 1; i++) {
+      await clickRandomRadioStationButton(page)
+      await getRadioCardFavouriteIcon(page).click()
+    }
+    await clickRandomRadioStationButton(page)
+    await getRadioCardFavouriteIcon(page).click()
+    await assertToastMessage(
+      page,
+      `Favourite station limit of ${MAX_FAVOURITE_STATIONS} reached`
+    )
+  })
+
+  test("should show error toast when favourite station limit is exceeded", async ({
+    page,
+  }) => {
+    test.setTimeout(30_000)
+    const MAX_FAVOURITE_STATIONS = 3
+    expect(
+      process.env.VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS,
+      ".env.local environment property VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS should be defined"
+    ).toBe(`${MAX_FAVOURITE_STATIONS}`)
+    await page.route("*/**/json/stations/search?*", async (route) => {
+      const json = [{ ...unitedStatesStation, stationuuid: uuid() }]
+      await route.fulfill({ json })
+    })
+    await page.goto(HOMEPAGE)
+    for (let i = 0; i < MAX_FAVOURITE_STATIONS; i++) {
+      await clickRandomRadioStationButton(page)
+      await getRadioCardFavouriteIcon(page).click()
+    }
+    await clickRandomRadioStationButton(page)
+    await getRadioCardFavouriteIcon(page).click()
+    await assertToastMessage(
+      page,
+      `Could not add favourite station. Exceeded limit of ${MAX_FAVOURITE_STATIONS}`
+    )
+  })
+})

--- a/frontend/tests/homepage.favourite.station.spec.ts
+++ b/frontend/tests/homepage.favourite.station.spec.ts
@@ -8,14 +8,12 @@ import {
   closeFavouriteStationsDrawer,
   getFavouriteStationsButton,
   getFavouriteStationsDrawer,
+  getRadioCardFavouriteIcon,
 } from "./constants/favouriteStationConstants"
 
 test.describe("radio station favourite feature", () => {
   function getRadioCardPopup(page: Page) {
     return page.locator("#map .radio-card")
-  }
-  function getRadioCardFavouriteIcon(page: Page) {
-    return page.locator("#map .radio-card .station-card-favourite-icon")
   }
   async function assertEmptyFavouriteList(page: Page) {
     await expect(

--- a/frontend/tests/homepage.filter.station.spec.ts
+++ b/frontend/tests/homepage.filter.station.spec.ts
@@ -47,7 +47,7 @@ test.describe("radio station search type", () => {
           .locator(".leaflet-proxy.leaflet-zoom-animated")
           .getAttribute("style")) || ""
       await getCountrySearchButton(page).click()
-      expect(
+      await expect(
         page.locator(".leaflet-proxy.leaflet-zoom-animated")
       ).not.toHaveAttribute("style", expectedStartMapPane)
     })
@@ -66,7 +66,7 @@ test.describe("radio station search type", () => {
           .getAttribute("style")) || ""
       // get second country in list of countries
       await page.locator(".country-slider-option").nth(1).click()
-      expect(
+      await expect(
         page.locator(".leaflet-proxy.leaflet-zoom-animated")
       ).not.toHaveAttribute("style", expectedFirstCountryMapPane)
     })
@@ -96,7 +96,7 @@ test.describe("radio station search type", () => {
           .getAttribute("style")) || ""
       // get second country in list of countries
       await page.locator(".country-slider-option").nth(1).click()
-      expect(
+      await expect(
         page.locator(".leaflet-proxy.leaflet-zoom-animated")
       ).toHaveAttribute("style", expectedStationMapPane)
     })


### PR DESCRIPTION
- Add RadioCard favourite station limit feature
- Fix bug in removing favourite station in RadioCard. (same `station` was incorrectly used in the filter, causing deletion of the entire favourite list) 
    - ![image](https://github.com/user-attachments/assets/9da4e88c-f03e-4357-9adc-d3b00b7457be)

GitHub Action secret added
- `VITE_MAX_FAVOURITE_STATIONS_ANONYMOUS`
- https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions