### PR TITLE
Add vercel.json for url rewrites to index route

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
Fix Vercel 404 errors when using radio station share link by rewriting url to index route

https://stackoverflow.com/questions/64815012/react-router-app-works-in-dev-but-not-after-vercel-deployment