### PR TITLE
Fix loading of same favourite station Map popup and center map popup for mobile view

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,15 +16,15 @@
         "react-dom": "18.3.1",
         "react-hook-form": "7.54.2",
         "react-icons": "5.4.0",
-        "react-router": "7.1.1",
-        "sonner": "1.7.1",
+        "react-router": "7.1.3",
+        "sonner": "1.7.2",
         "video.js": "8.21.0"
       },
       "devDependencies": {
         "@eslint/js": "9.18.0",
         "@playwright/test": "1.49.1",
         "@types/leaflet": "1.9.16",
-        "@types/node": "22.10.5",
+        "@types/node": "22.10.7",
         "@types/react": "18.3.13",
         "@types/react-dom": "18.3.1",
         "@vitejs/plugin-react": "4.3.4",
@@ -33,8 +33,8 @@
         "eslint-plugin-react-refresh": "0.4.18",
         "globals": "15.14.0",
         "typescript": "5.7.3",
-        "typescript-eslint": "8.19.1",
-        "vite": "6.0.7"
+        "typescript-eslint": "8.20.0",
+        "vite": "6.0.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1419,9 +1419,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.10.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-      "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+      "version": "22.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+      "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1457,17 +1457,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.1.tgz",
-      "integrity": "sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.20.0.tgz",
+      "integrity": "sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/type-utils": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/type-utils": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1487,16 +1487,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.1.tgz",
-      "integrity": "sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.20.0.tgz",
+      "integrity": "sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1512,14 +1512,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.1.tgz",
-      "integrity": "sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.20.0.tgz",
+      "integrity": "sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1"
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1530,14 +1530,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.1.tgz",
-      "integrity": "sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.20.0.tgz",
+      "integrity": "sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1",
+        "@typescript-eslint/typescript-estree": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.0"
       },
@@ -1554,9 +1554,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.1.tgz",
-      "integrity": "sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1568,14 +1568,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.1.tgz",
-      "integrity": "sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.20.0.tgz",
+      "integrity": "sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/visitor-keys": "8.19.1",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/visitor-keys": "8.20.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1634,16 +1634,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.1.tgz",
-      "integrity": "sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.20.0.tgz",
+      "integrity": "sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.19.1",
-        "@typescript-eslint/types": "8.19.1",
-        "@typescript-eslint/typescript-estree": "8.19.1"
+        "@typescript-eslint/scope-manager": "8.20.0",
+        "@typescript-eslint/types": "8.20.0",
+        "@typescript-eslint/typescript-estree": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1658,13 +1658,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.1.tgz",
-      "integrity": "sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.20.0.tgz",
+      "integrity": "sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.19.1",
+        "@typescript-eslint/types": "8.20.0",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -3231,9 +3231,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.1.tgz",
-      "integrity": "sha512-39sXJkftkKWRZ2oJtHhCxmoCrBCULr/HAH4IT5DHlgu/Q0FCPV0S4Lx+abjDTx/74xoZzNYDYbOZWlJjruyuDQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.3.tgz",
+      "integrity": "sha512-EezYymLY6Guk/zLQ2vRA8WvdUhWFEj5fcE3RfWihhxXBW7+cd1LsIiA3lmx+KCmneAGQuyBv820o44L2+TtkSA==",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/sonner": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.1.tgz",
-      "integrity": "sha512-b6LHBfH32SoVasRFECrdY8p8s7hXPDn3OHUFbZZbiB1ctLS9Gdh6rpX2dVrpQA0kiL5jcRzDDldwwLkSKk3+QQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.2.tgz",
+      "integrity": "sha512-zMbseqjrOzQD1a93lxahm+qMGxWovdMxBlkTbbnZdNqVLt4j+amF9PQxUCL32WfztOFt9t9ADYkejAL3jF9iNA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
@@ -3503,15 +3503,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.19.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.1.tgz",
-      "integrity": "sha512-LKPUQpdEMVOeKluHi8md7rwLcoXHhwvWp3x+sJkMuq3gGm9yaYJtPo8sRZSblMFJ5pcOGCAak/scKf1mvZDlQw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.20.0.tgz",
+      "integrity": "sha512-Kxz2QRFsgbWj6Xcftlw3Dd154b3cEPFqQC+qMZrMypSijPd4UanKKvoKDrJ4o8AIfZFKAF+7sMaEIR8mTElozA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.19.1",
-        "@typescript-eslint/parser": "8.19.1",
-        "@typescript-eslint/utils": "8.19.1"
+        "@typescript-eslint/eslint-plugin": "8.20.0",
+        "@typescript-eslint/parser": "8.20.0",
+        "@typescript-eslint/utils": "8.20.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3625,9 +3625,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-      "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.9.tgz",
+      "integrity": "sha512-MSgUxHcaXLtnBPktkbUSoQUANApKYuxZ6DrbVENlIorbhL2dZydTLaZ01tjUoE3szeFzlFk9ANOKk0xurh4MKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,15 +20,15 @@
     "react-dom": "18.3.1",
     "react-hook-form": "7.54.2",
     "react-icons": "5.4.0",
-    "react-router": "7.1.1",
-    "sonner": "1.7.1",
+    "react-router": "7.1.3",
+    "sonner": "1.7.2",
     "video.js": "8.21.0"
   },
   "devDependencies": {
     "@eslint/js": "9.18.0",
     "@playwright/test": "1.49.1",
     "@types/leaflet": "1.9.16",
-    "@types/node": "22.10.5",
+    "@types/node": "22.10.7",
     "@types/react": "18.3.13",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "4.3.4",
@@ -37,7 +37,7 @@
     "eslint-plugin-react-refresh": "0.4.18",
     "globals": "15.14.0",
     "typescript": "5.7.3",
-    "typescript-eslint": "8.19.1",
-    "vite": "6.0.7"
+    "typescript-eslint": "8.20.0",
+    "vite": "6.0.9"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -53,17 +53,17 @@ export default defineConfig({
         },
         viewport: {
           width: 1920,
-          height: 1080
+          height: 1080,
         },
       },
     },
     {
       name: "firefox",
       use: {
-        ...devices["Desktop Firefox"], 
+        ...devices["Desktop Firefox"],
         viewport: {
           width: 1920,
-          height: 1080
+          height: 1080,
         },
       },
     },
@@ -76,7 +76,7 @@ export default defineConfig({
     {
       name: "Mobile Chrome",
       use: {
-        ...devices["Pixel 5"],
+        ...devices["Galaxy S8"],
         contextOptions: {
           // https://github.com/microsoft/playwright/issues/13037
           permissions: ["clipboard-read", "clipboard-write"],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -51,11 +51,21 @@ export default defineConfig({
           // https://github.com/microsoft/playwright/issues/13037
           permissions: ["clipboard-read", "clipboard-write"],
         },
+        viewport: {
+          width: 1920,
+          height: 1080
+        },
       },
     },
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: {
+        ...devices["Desktop Firefox"], 
+        viewport: {
+          width: 1920,
+          height: 1080
+        },
+      },
     },
     // {
     //   name: "webkit",

--- a/frontend/src/context/MapProvider/MapProvider.tsx
+++ b/frontend/src/context/MapProvider/MapProvider.tsx
@@ -4,7 +4,7 @@ import { LatLngExpression } from "leaflet"
 
 type MapInfo = {
   station: Station | null
-  setStation: React.Dispatch<React.SetStateAction<Station | null>>
+  setStation: (station: Station | null) => void
   currentView: LatLngExpression
   setCurrentView: React.Dispatch<React.SetStateAction<LatLngExpression>>
 }
@@ -18,9 +18,13 @@ function MapProvider({ children }: { children: React.ReactNode }) {
     lng: 0,
   })
   const [station, setStation] = useState<Station | null>(null)
+  function setMapStation(station: Station | null) {
+    setCurrentView({lat: station?.geo_lat || 0, lng: station?.geo_long || 0})
+    setStation(station == null ? null : {...station})
+  }
   return (
     <MapContext.Provider
-      value={{ station, setStation, currentView, setCurrentView }}
+      value={{ station, setStation: setMapStation, currentView, setCurrentView }}
     >
       {children}
     </MapContext.Provider>

--- a/frontend/src/features/map/components/Map/Map.tsx
+++ b/frontend/src/features/map/components/Map/Map.tsx
@@ -17,21 +17,35 @@ type MapProps = {
 function Map(props: MapProps) {
   const [currentPopup, setCurrentPopup] = useState<L.Popup | null>(null)
   const [popupContainer, setPopupContainer] = useState<HTMLElement | null>(null)
+
   useEffect(() => {
     map = setupMap()
     return () => {
       map.remove()
     }
   }, [])
+
   useEffect(() => {
     if (currentPopup !== null && currentPopup.isOpen()) {
       // do not navigate when station is rendered to user
       return
     }
     if (map) {
-      map.panTo(props.latLng)
+      // navigate when lat lng changes (e.g. Radio Station "Countries" select)
+      map.invalidateSize({ pan: true, animate: true })
+      map.panTo(props.latLng, { animate: true })
     }
   }, [currentPopup, props.latLng])
+
+  useEffect(() => {
+    if (props.station == null || currentPopup == null || map == null) {
+      return
+    }
+    const location = getStationLocation(props.station)
+    map.invalidateSize({ pan: true, animate: true })
+    map.panTo(location, { animate: true })
+  }, [currentPopup, props.station])
+
   useEffect(() => {
     if (props.station == null) {
       return
@@ -48,12 +62,12 @@ function Map(props: MapProps) {
       .openOn(map)
     setPopupContainer(popupDiv)
     setCurrentPopup(popup)
-    map.panTo(location, { animate: true })
     return () => {
       popup.remove()
       setCurrentPopup(null)
     }
   }, [setPopupContainer, props.station])
+
   return (
     <div id="map">
       {popupContainer !== null &&

--- a/frontend/tests/constants/homepageConstants.ts
+++ b/frontend/tests/constants/homepageConstants.ts
@@ -15,6 +15,10 @@ export function getCountrySearchButton(page: Page) {
   return page.locator("#station-search-type-container .country-search-button")
 }
 
+export function getRadioStationMapPopupCloseButton(page: Page) {
+  return page.locator(".leaflet-popup-close-button")
+}
+
 export async function getToastMessages(page: Page) {
   const toasts = await page.locator(".toaster").all()
   const toastMessages = (

--- a/frontend/tests/homepage.favourite.station.spec.ts
+++ b/frontend/tests/homepage.favourite.station.spec.ts
@@ -265,20 +265,22 @@ test.describe("radio station favourite feature", () => {
     await expect(getFavouriteStationsDrawer(page)).not.toBeVisible()
     await expect(getRadioCardPopup(page)).toBeVisible()
     await expect(
-      page.locator("#map .radio-card").getByRole("heading", {
+      getRadioCardPopup(page).getByRole("heading", {
         name: unitedStatesStation.name,
         exact: true,
       })
     ).toBeVisible()
     await expect(
-      page.locator("#map .radio-card").getByRole("link", {
+      getRadioCardPopup(page).getByRole("link", {
         name: unitedStatesStation.homepage,
         exact: true,
       })
     ).toBeVisible()
   })
 
-  test("removing favourite station Map popup using 'x' button and loading same favourite station using favourite station drawer shows same station on Map", async ({ page }) => {
+  test("removing favourite station Map popup using 'x' button and loading same favourite station using favourite station drawer shows same station on Map", async ({
+    page,
+  }) => {
     await page.route("*/**/json/stations/search?*", async (route) => {
       const json = [unitedStatesStation]
       await route.fulfill({ json })
@@ -287,8 +289,12 @@ test.describe("radio station favourite feature", () => {
     await clickRandomRadioStationButton(page)
     await expect(page.locator("#map")).toBeVisible()
     await getRadioCardFavouriteIcon(page).click()
+    await getRadioStationMapPopupCloseButton(page).scrollIntoViewIfNeeded()
     await getRadioStationMapPopupCloseButton(page).click()
-    await expect(getRadioCardPopup(page), "should remove radio station card from Map").not.toBeVisible()
+    await expect(
+      getRadioCardPopup(page),
+      "should remove radio station card from Map"
+    ).not.toBeVisible()
     await getFavouriteStationsButton(page).click()
     await getFavouriteStationsDrawer(page)
       .locator(".favourite-station")
@@ -296,7 +302,16 @@ test.describe("radio station favourite feature", () => {
         name: "load station",
       })
       .click()
-    await expect(getRadioCardPopup(page), "should display same favourite station on the Map").toBeVisible()
+    await expect(
+      getRadioCardPopup(page),
+      "should display same favourite station on the Map"
+    ).toBeVisible()
+    await expect(
+      getRadioCardPopup(page).getByRole("heading", {
+        name: unitedStatesStation.name,
+        exact: true,
+      })
+    ).toBeVisible()
   })
 
   test("placeholder icon shows up for station with empty favicon", async ({

--- a/frontend/tests/homepage.favourite.station.spec.ts
+++ b/frontend/tests/homepage.favourite.station.spec.ts
@@ -1,6 +1,7 @@
 import test, { expect, Page } from "@playwright/test"
 import {
   clickRandomRadioStationButton,
+  getRadioStationMapPopupCloseButton,
   HOMEPAGE,
 } from "./constants/homepageConstants"
 import { stationWithMultipleTags, unitedStatesStation } from "./mocks/station"
@@ -150,7 +151,7 @@ test.describe("radio station favourite feature", () => {
     // check hover color for remove favourite station button (do not hover in button center, where icon is)
     await getFavouriteStationsDrawer(page)
       .locator(".favourite-station .remove-favourite-station-btn")
-      .hover({ position: { x: 5, y: 0 } })
+      .hover({ position: { x: 5, y: 2 } })
     await expect(
       getFavouriteStationsDrawer(page).locator(
         ".favourite-station .station-card-favourite-icon.selected"
@@ -275,6 +276,27 @@ test.describe("radio station favourite feature", () => {
         exact: true,
       })
     ).toBeVisible()
+  })
+
+  test("removing favourite station Map popup using 'x' button and loading same favourite station using favourite station drawer shows same station on Map", async ({ page }) => {
+    await page.route("*/**/json/stations/search?*", async (route) => {
+      const json = [unitedStatesStation]
+      await route.fulfill({ json })
+    })
+    await page.goto(HOMEPAGE)
+    await clickRandomRadioStationButton(page)
+    await expect(page.locator("#map")).toBeVisible()
+    await getRadioCardFavouriteIcon(page).click()
+    await getRadioStationMapPopupCloseButton(page).click()
+    await expect(getRadioCardPopup(page), "should remove radio station card from Map").not.toBeVisible()
+    await getFavouriteStationsButton(page).click()
+    await getFavouriteStationsDrawer(page)
+      .locator(".favourite-station")
+      .getByRole("button", {
+        name: "load station",
+      })
+      .click()
+    await expect(getRadioCardPopup(page), "should display same favourite station on the Map").toBeVisible()
   })
 
   test("placeholder icon shows up for station with empty favicon", async ({


### PR DESCRIPTION
# Fix loading of same favourite station Map popup not working - Fixes #124 
When a favourite station Map popup is closed and the user tries to load the same favourite station using the Favourite Stations Drawer, no new popup is present.
- This is due to the MapContext setStation not being changed as the station has not changed.

Solution => to perform a copy of the given station whenever the MapContext station is being set. So that it will treat each station as unique

# Center map popup for mobile view - Fixes #126 
For mobile view, there should be a pan when the station changes as well. The Map size should be invalidated before the pan
- https://leafletjs.com/reference.html#map-invalidatesize

`Map.tsx`
```typescript
  useEffect(() => {
    if (props.station == null || currentPopup == null || map == null) {
      return
    }
    const location = getStationLocation(props.station)
    map.invalidateSize({ pan: true, animate: true })
    map.panTo(location, { animate: true })
  }, [currentPopup, props.station])
```

