### PR TITLE
Fix radio station share url UUID check and update radio station playback error message

### DIFF
--- a/frontend/src/features/map/components/RadioCard/RadioCard.css
+++ b/frontend/src/features/map/components/RadioCard/RadioCard.css
@@ -15,3 +15,7 @@
 .favourite-icon {
   margin-left: auto;
 }
+
+.radio-card-error-text {
+  margin: 0;
+}

--- a/frontend/src/features/map/components/RadioCard/RadioCard.tsx
+++ b/frontend/src/features/map/components/RadioCard/RadioCard.tsx
@@ -78,11 +78,10 @@ function RadioCard(props: RadioCardProps) {
   function handleShareStation() {
     copyRadioStationShareUrl(station)
   }
-  function handleError(error: string) {
+  function handleError() {
     setError(
       "The media could not be loaded. Server failed or the playback format is not supported"
     )
-    console.error(error)
     toast.error("Could not play radio station")
   }
   function handleReady() {

--- a/frontend/src/features/map/components/RadioCard/RadioCard.tsx
+++ b/frontend/src/features/map/components/RadioCard/RadioCard.tsx
@@ -79,7 +79,10 @@ function RadioCard(props: RadioCardProps) {
     copyRadioStationShareUrl(station)
   }
   function handleError(error: string) {
-    setError(error)
+    setError(
+      "The media could not be loaded. Server failed or the playback format is not supported"
+    )
+    console.error(error)
     toast.error("Could not play radio station")
   }
   function handleReady() {
@@ -112,7 +115,10 @@ function RadioCard(props: RadioCardProps) {
         <StationCard.HomepageLink />
       </StationCard>
       {error ? (
-        <p className="error-text" data-testid="radio-card-playback-error">
+        <p
+          className="error-text radio-card-error-text"
+          data-testid="radio-card-playback-error"
+        >
           {error}
         </p>
       ) : (

--- a/frontend/src/pages/RadioStation/RadioStation.tsx
+++ b/frontend/src/pages/RadioStation/RadioStation.tsx
@@ -10,10 +10,11 @@ type RadioStationParams = {
 }
 
 function isInvalidUuid(uuid: string) {
-  const uuidV4regex = new RegExp(
-    /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
+  // check UUID Version 1 to 5 "[0-5]", version number is the first character of the third group: [VERSION_NUMBER][0-9A-F]{3}
+  const uuidregex = new RegExp(
+    /^[0-9A-F]{8}-[0-9A-F]{4}-[1-5][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i
   )
-  return !uuidV4regex.test(uuid)
+  return !uuidregex.test(uuid)
 }
 
 export default function RadioStation() {

--- a/frontend/tests/homepage.share.station.spec.ts
+++ b/frontend/tests/homepage.share.station.spec.ts
@@ -135,6 +135,113 @@ test.describe("share radio station feature", () => {
     expect(await getClipboardContent(page)).toBe(expectedUrl)
   })
 
+  test.describe("should not redirect to 404 page for valid stationuuid UUID Versions 1 to 5 in Radio Station Share URL", () => {
+    test("stationuuid UUID Version 1 should not redirect to 404 page", async ({
+      page,
+    }) => {
+      const stationuuid = "960a2547-e2e4-11e9-a8ba-52543be04c81"
+      await page.route(
+        `*/**/json/stations/byuuid?uuids=${stationuuid}`,
+        async (route) => {
+          const json = [{ ...unitedStatesStation, stationuuid }]
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + "/radio-station/" + stationuuid)
+      await expect(page.getByText("404 Not Found")).not.toBeVisible()
+      await expect(
+        page.locator("#map .radio-card").getByRole("heading", {
+          name: unitedStatesStation.name,
+          exact: true,
+        })
+      ).toBeVisible()
+    })
+
+    test("stationuuid UUID Version 2 should not redirect to 404 page", async ({
+      page,
+    }) => {
+      const stationuuid = "960a2547-e2e4-21e9-a8ba-52543be04c81"
+      await page.route(
+        `*/**/json/stations/byuuid?uuids=${stationuuid}`,
+        async (route) => {
+          const json = [{ ...unitedStatesStation, stationuuid }]
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + "/radio-station/" + stationuuid)
+      await expect(page.getByText("404 Not Found")).not.toBeVisible()
+      await expect(
+        page.locator("#map .radio-card").getByRole("heading", {
+          name: unitedStatesStation.name,
+          exact: true,
+        })
+      ).toBeVisible()
+    })
+
+    test("stationuuid UUID Version 3 should not redirect to 404 page", async ({
+      page,
+    }) => {
+      const stationuuid = "960a2547-e2e4-31e9-a8ba-52543be04c81"
+      await page.route(
+        `*/**/json/stations/byuuid?uuids=${stationuuid}`,
+        async (route) => {
+          const json = [{ ...unitedStatesStation, stationuuid }]
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + "/radio-station/" + stationuuid)
+      await expect(page.getByText("404 Not Found")).not.toBeVisible()
+      await expect(
+        page.locator("#map .radio-card").getByRole("heading", {
+          name: unitedStatesStation.name,
+          exact: true,
+        })
+      ).toBeVisible()
+    })
+
+    test("stationuuid UUID Version 4 should not redirect to 404 page", async ({
+      page,
+    }) => {
+      const stationuuid = "db93a00f-9191-46ab-9e87-ec9b373b3eee"
+      await page.route(
+        `*/**/json/stations/byuuid?uuids=${stationuuid}`,
+        async (route) => {
+          const json = [{ ...unitedStatesStation, stationuuid }]
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + "/radio-station/" + stationuuid)
+      await expect(page.getByText("404 Not Found")).not.toBeVisible()
+      await expect(
+        page.locator("#map .radio-card").getByRole("heading", {
+          name: unitedStatesStation.name,
+          exact: true,
+        })
+      ).toBeVisible()
+    })
+
+    test("stationuuid UUID Version 5 should not redirect to 404 page", async ({
+      page,
+    }) => {
+      const stationuuid = "b79cb3ba-745e-5d9a-8903-4a02327a7e09"
+      await page.route(
+        `*/**/json/stations/byuuid?uuids=${stationuuid}`,
+        async (route) => {
+          const json = [{ ...unitedStatesStation, stationuuid }]
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + "/radio-station/" + stationuuid)
+      await expect(page.getByText("404 Not Found")).not.toBeVisible()
+      await expect(
+        page.locator("#map .radio-card").getByRole("heading", {
+          name: unitedStatesStation.name,
+          exact: true,
+        })
+      ).toBeVisible()
+    })
+  })
+
   test("should redirect to 404 page when invalid UUID V4 radio station share url stationuuid is present in the url", async ({
     page,
   }) => {

--- a/frontend/tests/homepage.spec.ts
+++ b/frontend/tests/homepage.spec.ts
@@ -146,7 +146,7 @@ test.describe("random radio station", () => {
     await expect(
       page.locator("#map .radio-card").getByTestId("radio-card-playback-error")
     ).toHaveText(
-      /The media could not be loaded, either because the server or network failed or because the format is not supported/
+      /The media could not be loaded. Server failed or the playback format is not supported/
     )
   })
 


### PR DESCRIPTION
Fixes #127 
- UUID Check was missing for Version 1, 2, 3, 5. Only Version 4 was present.
- Added validation of UUID for version 1 to 5

Fixes #128 
- Fix flaky test that was failing as the longer error message for media playback error and element padding was pushing the 'x' close button on the Map Radio Station Card where the test could not view it in the current viewport