### PR TITLE
Update backend prod build and start script to use tsc instead of esbuild

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,6 @@
         "@types/jsdom": "21.1.7",
         "@types/node": "22.12.0",
         "@types/supertest": "6.0.2",
-        "esbuild": "0.24.2",
         "msw": "2.7.0",
         "supertest": "7.0.0",
         "tsx": "4.19.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "prod:build": "esbuild index.ts --bundle --splitting --platform=node --format=esm --packages=external --sourcemap=external --outdir=dist",
-    "prod:preview": "npm run build && node --enable-source-maps dist/index.js",
+    "prod:preview": "npm run prod:build && node --enable-source-maps dist/index.js",
     "prod:start": "node --enable-source-maps dist/index.js",
     "start": "tsc --build && node dist/index.js",
     "dev": "npx tsx watch index.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "prod:build": "esbuild index.ts --bundle --splitting --platform=node --format=esm --packages=external --sourcemap=external --outdir=dist",
-    "prod:preview": "npm run prod:build && node --enable-source-maps dist/index.js",
+    "prod:build": "tsc --build",
     "prod:start": "node --enable-source-maps dist/index.js",
     "start": "tsc --build && node dist/index.js",
     "dev": "npx tsx watch index.ts",
@@ -38,7 +37,6 @@
     "@types/jsdom": "21.1.7",
     "@types/node": "22.12.0",
     "@types/supertest": "6.0.2",
-    "esbuild": "0.24.2",
     "msw": "2.7.0",
     "supertest": "7.0.0",
     "tsx": "4.19.2",


### PR DESCRIPTION
On render.com, esbuild errors are present - `/bin/sh: 1: esbuild: not found`