### PR TITLE
Update backend trust proxy to two based on prod x-forwarded-for header

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -9,7 +9,7 @@ const PORT = process.env.PORT
 function setupApp() {
   const app = express()
   // https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues
-  app.set("trust proxy", 1) // Trust first proxy (reverse proxy)
+  app.set("trust proxy", 2) // Trust two proxy (reverse proxy)
 
   //@ts-ignore
   const testRouter = new Router()


### PR DESCRIPTION
https://httptoolkit.com/blog/what-is-x-forwarded-for/#2-picking-by-trusted-proxy-count

https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues

https://expressjs.com/en/guide/behind-proxies.html