### PR TITLE
Add proxy troubleshooting router based on environment variable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,10 +16,12 @@ PORT=3000
 PODCAST_INDEX_API_KEY="???"
 PODCAST_INDEX_API_SECRET="???"
 FRONTEND_ORIGIN="http://localhost:5173"
+ENABLE_PROXY_TROUBLESHOOTING="false"
 ```
 
 - `PODCAST_INDEX_API_KEY` and `PODCAST_INDEX_API_SECRET` is obtained from using an account created on https://podcastindex-org.github.io/docs-api/#overview--overview (enclosed in double quotes to escape characters such as `#`)
 - `FRONTEND_ORIGIN` is used to set the CORS headers for the backend endpoints. They will only allow the frontend origin (`(new URL()).origin` - https://developer.mozilla.org/en-US/docs/Web/API/URL/origin)
+- `ENABLE_PROXY_TROUBLESHOOTING` provide "true" to enable routes `/ip` and `/x-forwarded-for` for troubleshooting the `app.set("trust proxy", 3)` value to put so that the client ip is returned from route `/ip` (allows for more accurate rate limiting of users)
 
 # Running the backend application (Dev)
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,8 +1,11 @@
 import "dotenv/config"
-import express, { Router } from "express"
+import express from "express"
 import cors from "cors"
 import router from "./route/index.js"
-import { getCorsOptions } from "./middleware/cors.js"
+import {
+  getCorsOptions,
+  getProxyTroubleshootingRouter,
+} from "./middleware/cors.js"
 
 const PORT = process.env.PORT
 
@@ -10,18 +13,10 @@ function setupApp() {
   const app = express()
   // https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues
   app.set("trust proxy", 3) // Trust three proxy (reverse proxy)
-
-  //@ts-ignore
-  const testRouter = new Router()
-  //@ts-ignore
-  testRouter.get("/ip", (request, response) => response.send(request.ip))
-  //@ts-ignore
-  testRouter.get("/x-forwarded-for", (request, response) => {
-    console.log(request.headers)
-    response.send(request.headers["x-forwarded-for"])
-  })
-  app.use(testRouter)
-
+  if (process.env.ENABLE_PROXY_TROUBLESHOOTING === "true") {
+    // place before CORS for troubleshooting (won't apply CORS to the troubleshooting routes)
+    app.use(getProxyTroubleshootingRouter())
+  }
   app.use(cors(getCorsOptions()))
   app.use(express.json()) // middleware to parse json request body
   app.use(router)

--- a/backend/middleware/cors.ts
+++ b/backend/middleware/cors.ts
@@ -1,4 +1,5 @@
 import { CorsOptions } from "cors"
+import { Request, Response, Router } from "express"
 
 export function getCorsOptions(): CorsOptions {
   const frontendOrigin = process.env.FRONTEND_ORIGIN
@@ -22,6 +23,7 @@ export function getCorsOptions(): CorsOptions {
       }
     }, // Access-Control-Allow-Origin, allow only frontend origin
     methods: ["GET", "POST", "PUT", "DELETE"],
+    credentials: true, // Access-Control-Allow-Credentials for cookies
   }
 }
 
@@ -32,4 +34,20 @@ export function isValidUrl(url: string): boolean {
   } catch (error) {
     return false
   }
+}
+
+export function getProxyTroubleshootingRouter() {
+  //@ts-ignore
+  const troubleshootingRouter = new Router()
+  troubleshootingRouter.get("/ip", (request: Request, response: Response) =>
+    response.send(request.ip)
+  )
+  troubleshootingRouter.get(
+    "/x-forwarded-for",
+    (request: Request, response: Response) => {
+      console.log(request.headers)
+      response.send(request.headers["x-forwarded-for"])
+    }
+  )
+  return troubleshootingRouter
 }


### PR DESCRIPTION
To enable proxy endpoints `/ip` and `/x-forwarded-for`
- `ENABLE_PROXY_TROUBLESHOOTING` = "true"
