### PR TITLE
Fix podcast card title dark theme text color

### DIFF
--- a/frontend/src/components/PodcastCard/PodcastCard.css
+++ b/frontend/src/components/PodcastCard/PodcastCard.css
@@ -24,6 +24,7 @@
 
 .podcast-card-title {
   font-weight: bold;
+  color: var(--text-color);
   font-size: clamp(0.7rem, 0.7rem + 1vw, 1rem);
 }
 


### PR DESCRIPTION
The text color was not changed for the podcast card in dark theme

#155 