### PR TITLE
Add podcast image backend endpoint to resize and compress image sources

### DIFF
--- a/backend/__tests__/route/podcast.episode.test.ts
+++ b/backend/__tests__/route/podcast.episode.test.ts
@@ -28,6 +28,14 @@ function mockRateLimiters() {
 describe("GET /api/podcast/episodes", () => {
   const expectedOrigin = getFrontendOrigin() || ""
 
+  beforeEach(() => {
+    mockRateLimiters()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   function getExpectedEpisodeData(podcastResponse: any, episodeItems: any[]) {
     // convert PodcastIndex API episode "items" response array to expected /api/podcast/episodes json response for "data"
     return {
@@ -79,14 +87,6 @@ describe("GET /api/podcast/episodes", () => {
       }),
     }
   }
-
-  beforeEach(() => {
-    mockRateLimiters()
-  })
-
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
 
   describe("invalid parameters", () => {
     describe("id parameter", () => {

--- a/backend/__tests__/route/podcast.episode.test.ts
+++ b/backend/__tests__/route/podcast.episode.test.ts
@@ -20,6 +20,7 @@ function mockRateLimiters() {
       default: {
         getTrendingPodcastLimiter: getMockMiddleware(),
         getPodcastEpisodesLimiter: getMockMiddleware(),
+        getPodcastImageConversionLimiter: getMockMiddleware(),
       },
     }
   })

--- a/backend/__tests__/route/podcast.image.test.ts
+++ b/backend/__tests__/route/podcast.image.test.ts
@@ -1,0 +1,275 @@
+import request from "supertest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { NextFunction, Request, Response } from "express"
+import { getFrontendOrigin } from "../cors/origin.js"
+import { setupApp } from "../../index.js"
+
+function getMockMiddleware() {
+  return (request: Request, response: Response, next: NextFunction) => next()
+}
+
+function mockRateLimiters() {
+  vi.mock("../../middleware/rateLimiter.js", () => {
+    return {
+      default: {
+        getTrendingPodcastLimiter: getMockMiddleware(),
+        getPodcastEpisodesLimiter: getMockMiddleware(),
+      },
+    }
+  })
+}
+
+describe("GET /api/podcast/image", () => {
+  const expectedOrigin = getFrontendOrigin() || ""
+
+  beforeEach(() => {
+    mockRateLimiters()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Enable selectively, it will run against the actual Supabase backend and storage (as no mocks have been done)
+  // Asserts that the compressed and resized image data has the same output bytes in base64 (image/webp)
+  test.skip("should specify response content type of application/json", async () => {
+    const payload = {
+      url: "https://placehold.co/3000x3000",
+      width: 200,
+      height: 200,
+    }
+    const app = setupApp()
+    const response = await request(app)
+      .post(`/api/podcast/image`)
+      .send(payload)
+      .set("Content-Type", "application/json")
+      .set("Accept", "application/json")
+      .set("Origin", expectedOrigin)
+    expect(response.headers["content-type"]).toEqual(
+      expect.stringContaining("image/webp")
+    )
+    expect(response.status).toBe(200)
+    // WARNING: Compares the actual base64 bytes of the image returned from the production application
+    // From source image https://placehold.co/3000x3000
+    // Could break this test if the compression image parameters change or the resize is different!
+    expect(Buffer.from(response.body).toString("base64")).toBe(
+      "UklGRhoCAABXRUJQVlA4IA4CAADwGgCdASrIAMgAPqlUqE6mJSQiIXbYgMAVCWlu4XcmCOAfYD9AJH311R26bMW2MXtBlw6VgGy1vwUKFChQoUKFCjEWylRfJH7OKhrItlKi+SP2cVDWRbKVF8kfitKwMkxlBEklcSKkcRueEaqDkBDzoNDrq2lBnxlpRXeCMDw2Cca9KOWAg4g6VaK0t3+d+NjiGH25dViqTbSWUATgV/mrCjJ8jYxmir3QKQ37Z+s6Gno9H5XUp/KZQLItlKi+SP2cVDWRbKVF8kfs4qGsi2UqL5I/ZxUNZFspUXyR+zhsAAD+/3XdNcIfhqJaXiL+ucwl5fXk6jzW7UrBa9vz1zdPKwXArGGSgKRmALLwR8+zaOAt4FmthLoM6Dc1xT7/YPR2XNWmSnFUEIjjJ20nNwrulMp8cXiffXMWoKMLH/0xccuee01O7pGpeaVvgeZ36rYAiTxn9c5olFCTi+Iwk6BFHxvN9CfM2npDYqFuyqCJnAVjV9OtZdfLE9ZaFtXNpwbZMHvnOvtQXH4kfSdt2nMYN52Zzh4qMLys0luf0fd5q5dC0XVP0KhJMp6iWYZ3pGgm51erhcjaFnLBWhMtkNLfcDymiy5Ak0vWskz0l3V9WdrOM89Fz/I4LZZT7dIyQsKwvNzx/qemIYJKmQsMrNfIqWR5uiH5bP3/MA2LV5aDG4oa4auYTJdT0J20cQAA"
+    )
+  })
+
+  describe("invalid parameters", () => {
+    // TODO check for "height" in request body, check that the size is valid
+    describe("height parameter", () => {
+      test("should return status 400 for missing 'height' in request body", async () => {
+        const payload = { url: "https://example.com", width: 100 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'height' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'height' smaller than 16 in request body", async () => {
+        const payload = { height: 15, url: "https://example.com", width: 100 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'height' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'height' greater than 500 in request body", async () => {
+        const payload = { height: 501, url: "https://example.com", width: 100 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'height' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'height' with negative value in request body", async () => {
+        const payload = { height: -1, url: "https://example.com", width: 100 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'height' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'height' with zero value in request body", async () => {
+        const payload = { height: 0, url: "https://example.com", width: 100 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'height' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+    })
+
+    describe("width parameter", () => {
+      test("should return status 400 for missing 'width' in request body", async () => {
+        const payload = { url: "https://example.com", height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'width' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'width' smaller than 16 in request body", async () => {
+        const payload = { width: 15, url: "https://example.com", height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'width' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'width' larger than 500 in request body", async () => {
+        const payload = { width: 501, url: "https://example.com", height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'width' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'width' with negative value in request body", async () => {
+        const payload = { width: -2, url: "https://example.com", height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'width' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+
+      test("should return status 400 for 'width' with zero in request body", async () => {
+        const payload = { width: 0, url: "https://example.com", height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining([
+              "'width' should be between 16 and 500",
+            ]),
+          })
+        )
+      })
+    })
+
+    describe("url parameter", () => {
+      test("should return status 400 for missing 'url' in request body", async () => {
+        const payload = { width: 200, height: 200 }
+        const app = setupApp()
+        const response = await request(app)
+          .post(`/api/podcast/image`)
+          .send(payload)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("Origin", expectedOrigin)
+        expect(response.status).toBe(400)
+        expect(response.body).toEqual(
+          expect.objectContaining({
+            errors: expect.arrayContaining(["'url' should be a valid url"]),
+          })
+        )
+      })
+    })
+  })
+})

--- a/backend/__tests__/route/podcast.image.test.ts
+++ b/backend/__tests__/route/podcast.image.test.ts
@@ -14,6 +14,7 @@ function mockRateLimiters() {
       default: {
         getTrendingPodcastLimiter: getMockMiddleware(),
         getPodcastEpisodesLimiter: getMockMiddleware(),
+        getPodcastImageConversionLimiter: getMockMiddleware(),
       },
     }
   })

--- a/backend/__tests__/route/podcast.trending.test.ts
+++ b/backend/__tests__/route/podcast.trending.test.ts
@@ -15,6 +15,7 @@ function mockRateLimiters() {
       default: {
         getTrendingPodcastLimiter: getMockMiddleware(),
         getPodcastEpisodesLimiter: getMockMiddleware(),
+        getPodcastImageConversionLimiter: getMockMiddleware(),
       },
     }
   })

--- a/backend/api/storage/storageClient.ts
+++ b/backend/api/storage/storageClient.ts
@@ -1,0 +1,137 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
+import { Database } from "./supabase.js"
+
+// Create singleton for the supabase client
+let instance: StorageClient
+
+class StorageClient {
+  private supabase: SupabaseClient<Database, "public", any>
+
+  constructor() {
+    if (instance) {
+      throw new Error("Unable to create multiple StorageClient instances")
+    }
+    if (process.env.SUPABASE_PROJECT_URL == null) {
+      throw new Error(
+        "Invalid null environment variable 'SUPABASE_PROJECT_URL'"
+      )
+    }
+    if (process.env.SUPABASE_PROJECT_SERVICE_ROLE_API_KEY == null) {
+      throw new Error(
+        "Invalid null environment variable 'SUPABASE_PROJECT_SERVICE_ROLE_API_KEY'"
+      )
+    }
+    const supabase = createClient<Database>(
+      process.env.SUPABASE_PROJECT_URL,
+      process.env.SUPABASE_PROJECT_SERVICE_ROLE_API_KEY
+    )
+    this.supabase = supabase
+    instance = this
+  }
+
+  getInstance() {
+    return this
+  }
+
+  private decode(base64FileData: string) {
+    return Buffer.from(base64FileData, "base64")
+  }
+
+  async uploadFileAndUpdateDatabase({
+    base64FileData,
+    fileName,
+    width,
+    height,
+    contentType,
+    url,
+  }: {
+    base64FileData: string
+    fileName: string
+    width: number
+    height: number
+    contentType: string
+    url: string
+  }) {
+    // https://supabase.com/docs/reference/javascript/storage-from-upload
+    const filePath = `public/w${width}_h${height}/${fileName}`
+    const uploadFilePromise = this.supabase.storage
+      .from("podcast-image") // bucket name
+      .upload(filePath, this.decode(base64FileData), {
+        contentType: contentType, // e.g. "image/png"
+      })
+    const insertDatabasePromise = this.supabase
+      .from("podcast_images") // database name
+      .insert({ url: url, storage_file_name: fileName })
+    const promises = await Promise.allSettled([
+      uploadFilePromise,
+      insertDatabasePromise,
+    ])
+    const deleteOperationsBasedOnPromises = [
+      async () => {
+        // delete upload file
+        const { error } = await this.supabase.storage
+          .from("podcast-image") // bucket name
+          .remove([filePath])
+        if (error) {
+          console.error(
+            `uploadFileAndUpdateDatabase(): could not delete upload file. image url ${url}, storage file path: ${filePath}`
+          )
+        } else {
+          console.log(`uploadFileAndUpdateDatabase(): successful deletion of `)
+        }
+      },
+      async () => {
+        // delete database row from table "podcast_images"
+        const { status } = await this.supabase
+          .from("podcast_images")
+          .delete()
+          .eq("url", url)
+          .select()
+        if (status !== 200) {
+          console.error(
+            `uploadFileAndUpdateDatabase(): could not delete database row for table 'podcast_images'. image url ${url}`
+          )
+        }
+      },
+    ]
+    if (promises.some((p) => p.status === "rejected")) {
+      for (let i = 0; i < promises.length; i++) {
+        const p = promises[i]
+        // if any promise has "status": "rejected", we need to perform a delete for those that were fulfilled
+        if (p.status === "fulfilled") {
+          console.error(
+            `uploadFileAndUpdateDatabase(): attempt to delete for index ${i}. image url: ${url}, width: ${width}, height: ${height}`
+          )
+          await deleteOperationsBasedOnPromises[i]()
+        }
+      }
+    }
+  }
+
+  getFilePublicUrl(fileName: string, width: number, height: number): string {
+    // https://supabase.com/docs/reference/javascript/storage-from-getpublicurl
+    // does not check if file path is valid
+    const { data } = this.supabase.storage
+      .from("podcast-image") // bucket name
+      .getPublicUrl(`public/w${width}_h${height}/${fileName}`)
+    return data.publicUrl
+  }
+
+  async getExistingFile(url: string): Promise<string | null> {
+    const { data, error, status } = await this.supabase
+      .from("podcast_images") // database table
+      .select("storage_file_name") // columns to return in data
+      .eq("url", url)
+      .limit(1)
+    if (data == null) {
+      return null
+    }
+    if (data[0] && data[0].storage_file_name) {
+      return data[0].storage_file_name
+    }
+    return null
+  }
+}
+
+const singletonStorageClient = Object.freeze(new StorageClient())
+export default singletonStorageClient

--- a/backend/api/storage/supabase.ts
+++ b/backend/api/storage/supabase.ts
@@ -1,0 +1,167 @@
+// https://supabase.com/docs/reference/javascript/typescript-support
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          operationName?: string
+          query?: string
+          variables?: Json
+          extensions?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      podcast_images: {
+        Row: {
+          created_at: string
+          storage_file_name: string
+          url: string
+        }
+        Insert: {
+          created_at?: string
+          storage_file_name: string
+          url: string
+        }
+        Update: {
+          created_at?: string
+          storage_file_name?: string
+          url?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type PublicSchema = Database[Extract<keyof Database, "public">]
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+      PublicSchema["Views"])
+  ? (PublicSchema["Tables"] &
+      PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+  ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+  ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+  : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+  ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  : never

--- a/backend/middleware/cors.ts
+++ b/backend/middleware/cors.ts
@@ -1,3 +1,4 @@
+import { decodeHTML } from "entities"
 import { CorsOptions } from "cors"
 import { Request, Response, Router } from "express"
 
@@ -29,7 +30,7 @@ export function getCorsOptions(): CorsOptions {
 
 export function isValidUrl(url: string): boolean {
   try {
-    new URL(url)
+    new URL(decodeHTML(url))
     return true
   } catch (error) {
     return false

--- a/backend/middleware/rateLimiter.ts
+++ b/backend/middleware/rateLimiter.ts
@@ -31,4 +31,23 @@ const getPodcastEpisodesLimiter = rateLimit({
   },
 })
 
-export default { getTrendingPodcastLimiter, getPodcastEpisodesLimiter }
+const getPodcastImageConversionLimiter = rateLimit({
+  windowMs: 20 * 1000,
+  limit: 1, // Limit each IP to "X" requests per window
+  standardHeaders: "draft-7",
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  handler: (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    options: Options
+  ) => {
+    res.status(options.statusCode).send(options.message)
+  },
+})
+
+export default {
+  getTrendingPodcastLimiter,
+  getPodcastEpisodesLimiter,
+  getPodcastImageConversionLimiter,
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,15 +8,19 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "2.48.1",
         "cors": "2.8.5",
         "dayjs": "1.11.13",
         "dompurify": "^3.2.4",
         "dotenv": "16.4.7",
+        "entities": "6.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",
         "express-validator": "7.2.1",
         "jsdom": "^26.0.0",
-        "ky": "1.7.4"
+        "ky": "1.7.4",
+        "nanoid": "5.0.9",
+        "sharp": "0.33.5"
       },
       "devDependencies": {
         "@types/cors": "2.8.17",
@@ -193,6 +197,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.1.tgz",
+      "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -620,6 +634,367 @@
         "node": ">=18"
       }
     },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@inquirer/confirm": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.3.tgz",
@@ -997,6 +1372,102 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.67.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
+      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.18.1.tgz",
+      "integrity": "sha512-dWDnoC0MoDHKhaEOrsEKTadWQcBNknZVQcSgNE/Q2wXh05mhCL1ut/jthRUrSbYcqIw/CEjhaeIPp7dLarT0bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
+      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
+        "@types/phoenix": "^1.5.4",
+        "@types/ws": "^8.5.10",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.48.1.tgz",
+      "integrity": "sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.67.3",
+        "@supabase/functions-js": "2.4.4",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.18.1",
+        "@supabase/realtime-js": "2.11.2",
+        "@supabase/storage-js": "2.7.1"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -1112,11 +1583,16 @@
       "version": "22.13.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
       "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.18",
@@ -1199,6 +1675,15 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.0.5",
@@ -1561,11 +2046,23 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1578,8 +2075,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1744,6 +2250,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dezalgo": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
@@ -1813,9 +2328,9 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -2367,6 +2882,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2621,10 +3142,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "dev": true,
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.9.tgz",
+      "integrity": "sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==",
       "funding": [
         {
           "type": "github",
@@ -2633,10 +3153,10 @@
       ],
       "license": "MIT",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/negotiator": {
@@ -2716,6 +3236,18 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2782,6 +3314,25 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/proxy-addr": {
@@ -2975,6 +3526,18 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
@@ -3034,6 +3597,45 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -3125,6 +3727,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
       }
     },
     "node_modules/source-map-js": {
@@ -3372,6 +3983,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.19.2",
@@ -3885,7 +4503,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,15 +21,19 @@
   "homepage": "https://github.com/JeremyLoh/xtal#readme",
   "description": "Backend for xtal application",
   "dependencies": {
+    "@supabase/supabase-js": "2.48.1",
     "cors": "2.8.5",
     "dayjs": "1.11.13",
     "dompurify": "^3.2.4",
     "dotenv": "16.4.7",
+    "entities": "6.0.0",
     "express": "4.21.2",
     "express-rate-limit": "7.5.0",
     "express-validator": "7.2.1",
     "jsdom": "^26.0.0",
-    "ky": "1.7.4"
+    "ky": "1.7.4",
+    "nanoid": "5.0.9",
+    "sharp": "0.33.5"
   },
   "devDependencies": {
     "@types/cors": "2.8.17",

--- a/backend/route/index.ts
+++ b/backend/route/index.ts
@@ -1,10 +1,12 @@
 import { Router } from "express"
 import podcastTrendingRouter from "./podcast/trending.js"
 import podcastEpisodeRouter from "./podcast/episode.js"
+import podcastImageRouter from "./podcast/image.js"
 
 const router = Router()
 
 router.use(podcastTrendingRouter)
 router.use(podcastEpisodeRouter)
+router.use(podcastImageRouter)
 
 export default router

--- a/backend/route/podcast/image.ts
+++ b/backend/route/podcast/image.ts
@@ -1,0 +1,49 @@
+import { decodeHTML } from "entities"
+import { Request, Response, Router } from "express"
+import { checkSchema, matchedData, validationResult } from "express-validator"
+import { getPodcastImageValidationSchema } from "../../validation/podcastImageValidation.js"
+import { getImage } from "../../service/podcastImageService.js"
+
+const router = Router()
+
+function isValidUrl(url: string) {
+  try {
+    new URL(decodeHTML(url))
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
+router.post(
+  "/api/podcast/image",
+  checkSchema(getPodcastImageValidationSchema, ["body"]),
+  async (request: Request, response: Response) => {
+    const result = validationResult(request)
+    const isInvalidUrl = !isValidUrl(decodeHTML(request.body.url))
+    if (!result.isEmpty() || isInvalidUrl) {
+      const validationErrors = result.array().map((error) => error.msg)
+      response.status(400).send({
+        errors: isInvalidUrl
+          ? ["'url' should be a valid url"].concat(validationErrors)
+          : validationErrors,
+      })
+      return
+    }
+    const { url, width, height } = matchedData(request)
+    try {
+      const imageBuffer = await getImage(
+        decodeHTML(url),
+        Number(width),
+        Number(height)
+      )
+      response.contentType("image/webp")
+      response.status(200).send(Buffer.from(imageBuffer))
+    } catch (error: any) {
+      console.error("POST /api/podcast/image error:", error.message)
+      response.status(500).send("Internal Server Error")
+    }
+  }
+)
+
+export default router

--- a/backend/route/podcast/image.ts
+++ b/backend/route/podcast/image.ts
@@ -3,21 +3,15 @@ import { Request, Response, Router } from "express"
 import { checkSchema, matchedData, validationResult } from "express-validator"
 import { getPodcastImageValidationSchema } from "../../validation/podcastImageValidation.js"
 import { getImage } from "../../service/podcastImageService.js"
+import rateLimiter from "../../middleware/rateLimiter.js"
+import { isValidUrl } from "../../middleware/cors.js"
 
 const router = Router()
-
-function isValidUrl(url: string) {
-  try {
-    new URL(decodeHTML(url))
-    return true
-  } catch (error) {
-    return false
-  }
-}
 
 router.post(
   "/api/podcast/image",
   checkSchema(getPodcastImageValidationSchema, ["body"]),
+  rateLimiter.getPodcastImageConversionLimiter,
   async (request: Request, response: Response) => {
     const result = validationResult(request)
     const isInvalidUrl = !isValidUrl(decodeHTML(request.body.url))

--- a/backend/route/podcast/image.ts
+++ b/backend/route/podcast/image.ts
@@ -38,7 +38,7 @@ router.post(
         Number(height)
       )
       response.contentType("image/webp")
-      response.status(200).send(Buffer.from(imageBuffer))
+      response.status(200).send(imageBuffer)
     } catch (error: any) {
       console.error("POST /api/podcast/image error:", error.message)
       response.status(500).send("Internal Server Error")

--- a/backend/service/podcastImageService.ts
+++ b/backend/service/podcastImageService.ts
@@ -7,7 +7,7 @@ export async function getImage(
   url: string,
   width: number,
   height: number
-): Promise<ArrayBuffer> {
+): Promise<Buffer> {
   const storageClient = StorageClient.getInstance()
   const { exists, fileName } = await checkForExistingImage(url)
   if (exists && fileName) {

--- a/backend/service/podcastImageService.ts
+++ b/backend/service/podcastImageService.ts
@@ -1,0 +1,78 @@
+import ky from "ky"
+import sharp from "sharp"
+import { nanoid } from "nanoid"
+import StorageClient from "../api/storage/storageClient.js"
+
+export async function getImage(
+  url: string,
+  width: number,
+  height: number
+): Promise<ArrayBuffer> {
+  const storageClient = StorageClient.getInstance()
+  const { exists, fileName } = await checkForExistingImage(url)
+  if (exists && fileName) {
+    const filePublicUrl = storageClient.getFilePublicUrl(
+      fileName,
+      width,
+      height
+    )
+    console.log(`getImage(): file already exists ${fileName}`)
+    const existingImageBuffer = await downloadImageFromUrl(filePublicUrl)
+    return existingImageBuffer
+  } else {
+    const newImageBuffer = await storeNewImage(url, width, height)
+    return newImageBuffer
+  }
+}
+
+async function storeNewImage(url: string, width: number, height: number) {
+  const storageClient = StorageClient.getInstance()
+  const imageArrayBuffer = await downloadImageFromUrl(url)
+  const resizedAndCompressedImageBuffer = await resizeAndCompressImage(
+    imageArrayBuffer,
+    width,
+    height
+  )
+  const uploadFileName = nanoid() + ".webp"
+  // upload file to storage bucket (make sure size is smaller than 10MB) (buffer.byteLength)
+  await storageClient.uploadFileAndUpdateDatabase({
+    contentType: "image/webp",
+    fileName: uploadFileName,
+    base64FileData: resizedAndCompressedImageBuffer.toString("base64"),
+    width,
+    height,
+    url,
+  })
+  return resizedAndCompressedImageBuffer
+}
+
+async function checkForExistingImage(url: string) {
+  const storageClient = StorageClient.getInstance()
+  const fileName = await storageClient.getExistingFile(url)
+  if (fileName) {
+    return {
+      exists: true,
+      fileName: fileName,
+    }
+  }
+  return {
+    exists: false,
+    fileName: null,
+  }
+}
+
+async function downloadImageFromUrl(url: string): Promise<Buffer> {
+  const arrayBuffer = await ky.get(url, { retry: 0 }).arrayBuffer()
+  return Buffer.from(arrayBuffer)
+}
+
+async function resizeAndCompressImage(
+  buffer: ArrayBuffer,
+  width: number,
+  height: number
+) {
+  return await sharp(buffer)
+    .resize(width, height, { fit: "cover" })
+    .webp({ quality: 65, effort: 2, lossless: false })
+    .toBuffer()
+}

--- a/backend/validation/podcastImageValidation.ts
+++ b/backend/validation/podcastImageValidation.ts
@@ -1,0 +1,28 @@
+import { Schema } from "express-validator"
+
+export const getPodcastImageValidationSchema: Schema = {
+  url: {
+    optional: false,
+    escape: true,
+    isLength: {
+      options: { min: 1, max: 2048 },
+      errorMessage: "'url' should be a valid url",
+    },
+  },
+  width: {
+    optional: false,
+    escape: true,
+    isInt: {
+      options: { min: 16, max: 500 },
+      errorMessage: "'width' should be between 16 and 500",
+    },
+  },
+  height: {
+    optional: false,
+    escape: true,
+    isInt: {
+      options: { min: 16, max: 500 },
+      errorMessage: "'height' should be between 16 and 500",
+    },
+  },
+}


### PR DESCRIPTION
Resolves #150 

Created a new backend `POST` endpoint `/api/podcast/image` that can handle 20 image conversion requests per second (rate limit based on user IP)
- Receives `url` that is the original url of the image to be converted
- The `width` and `height` of resize
- Compression of the image bytes to `webp` format will also be performed by `sharp` npm package. To reduce the file sizes drastically
- The endpoint will return the image bytes in the response body as MIME type `image/webp` for the frontend to use in the `<img>` `src=` attribute

**Add two more backend `.env` environment variables that need to be secret**
- `SUPABASE_PROJECT_URL`
- `SUPABASE_PROJECT_SERVICE_ROLE_API_KEY`

Created Supabase database (PostgreSQL) and Supabase Storage (AWS S3 bucket)
- Database will be used to keep track of what original url => storage file name
- Storage will be used to store the `public/w200_h200/<file_name>.webp` files. The `<file_name>` is created by using `nanoid` (uuid). This makes the file names unpredictable