### PR TITLE
Fix initial incorrect loading spinner display when fetching podcast data

### DIFF
--- a/frontend/src/pages/PodcastLayout/PodcastLayout.tsx
+++ b/frontend/src/pages/PodcastLayout/PodcastLayout.tsx
@@ -1,5 +1,5 @@
 import "./PodcastLayout.css"
-import { preconnect } from "react-dom"
+import { preconnect, prefetchDNS } from "react-dom"
 import { Outlet } from "react-router"
 import PodcastPlayer from "../../features/podcast/player/PodcastPlayer"
 
@@ -7,6 +7,7 @@ const BACKEND_ORIGIN: string = import.meta.env.VITE_BACKEND_ORIGIN
 
 export default function PodcastLayout() {
   preconnect(BACKEND_ORIGIN)
+  prefetchDNS(BACKEND_ORIGIN)
 
   return (
     <>

--- a/frontend/src/pages/podcast/PodcastCategoryPage/PodcastCategoryPage.tsx
+++ b/frontend/src/pages/podcast/PodcastCategoryPage/PodcastCategoryPage.tsx
@@ -46,12 +46,12 @@ export default function PodcastCategoryPage() {
           setTrendingPodcasts(podcasts.data)
         } else {
           setTrendingPodcasts(null)
+          setLoading(false) // prevent infinite load on no data
         }
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         toast.error(error.message)
-      } finally {
-        setLoading(false)
+        setLoading(false) // prevent infinite load on error
       }
     },
     [categoryName]
@@ -69,6 +69,14 @@ export default function PodcastCategoryPage() {
       abortControllerTrending.current?.abort()
     }
   }, [getPodcasts, categoryName, sinceDaysBefore])
+
+  useEffect(() => {
+    // update loading state to false after set state has been run on the trending podcasts
+    // prevents display of "no podcasts available" element due to trendingPodcasts = null, and loading = false
+    if (trendingPodcasts) {
+      setLoading(false)
+    }
+  }, [trendingPodcasts])
 
   async function handlePodcastRefresh(
     filters: {

--- a/frontend/tests/constants/homepageConstants.ts
+++ b/frontend/tests/constants/homepageConstants.ts
@@ -25,7 +25,7 @@ export function getRadioStationMapPopupCloseButton(page: Page) {
 
 export async function getToastMessages(page: Page) {
   // wait some time for toasts to load fully
-  await page.waitForTimeout(1000)
+  await page.waitForTimeout(2000)
   const toasts = await page.locator(".toaster").all()
   const toastMessages = (
     await Promise.all(toasts.map((locator) => locator.allTextContents()))

--- a/frontend/tests/podcast/homepage/podcast.category.spec.ts
+++ b/frontend/tests/podcast/homepage/podcast.category.spec.ts
@@ -64,7 +64,7 @@ test.describe("Podcast Homepage /podcasts", () => {
       })
       await page.goto(HOMEPAGE + "/podcasts")
       await expect(page).toHaveTitle(/xtal - podcasts/)
-      expect(getRefreshPodcastCategoryButton(page)).toBeVisible()
+      await expect(getRefreshPodcastCategoryButton(page)).toBeVisible()
 
       shouldFetchData = true
       await getRefreshPodcastCategoryButton(page).click()


### PR DESCRIPTION
Resolves #188 

[feat: add dns prefetch for podcast backend](https://github.com/JeremyLoh/xtal/pull/189/commits/f0fe68722b579a6b2ce882daae94e32e659e537f)

[fix: add missing await in podcast category test](https://github.com/JeremyLoh/xtal/pull/189/commits/5c60682992487b8ac7a70527a61b88ea4d4de79a)

[fix: increase timeout for toast message](https://github.com/JeremyLoh/xtal/pull/189/commits/9ab5ea5518e6425febbe69f3cc3dd5b417634842)