### PR TITLE
Extract PodcastEpisodeProvider to PodcastLayout

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,6 @@ import { BrowserRouter, Routes, Route } from "react-router"
 import ThemeProvider from "./context/ThemeProvider/ThemeProvider.tsx"
 import MapProvider from "./context/MapProvider/MapProvider.tsx"
 import FavouriteStationsProvider from "./context/FavouriteStationsProvider/FavouriteStationsProvider.tsx"
-import PodcastEpisodeProvider from "./context/PodcastEpisodeProvider/PodcastEpisodeProvider.tsx"
 import Root from "./Root.tsx"
 import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary.tsx"
 import Spinner from "./components/Spinner/Spinner.tsx"
@@ -32,38 +31,36 @@ createRoot(document.getElementById("root")!).render(
     <ThemeProvider>
       <MapProvider>
         <FavouriteStationsProvider>
-          <PodcastEpisodeProvider>
-            <BrowserRouter>
-              <ErrorBoundary fallback={<NotFoundPage />}>
-                <Suspense fallback={<Spinner isLoading={true} />}>
-                  <Routes>
-                    <Route path="/" element={<Root />}>
-                      <Route element={<HomeLayout />}>
-                        <Route index element={<HomePage />} />
-                        <Route
-                          path="radio-station/:stationuuid"
-                          element={<RadioStation />}
-                        />
-                      </Route>
-                      <Route element={<PodcastLayout />}>
-                        <Route path="/podcasts" element={<PodcastHomePage />} />
-                        <Route
-                          path="/podcasts/:podcastTitle/:podcastId"
-                          element={<PodcastDetailPage />}
-                        />
-                        <Route
-                          path="/podcasts/:categoryName"
-                          element={<PodcastCategoryPage />}
-                        />
-                      </Route>
+          <BrowserRouter>
+            <ErrorBoundary fallback={<NotFoundPage />}>
+              <Suspense fallback={<Spinner isLoading={true} />}>
+                <Routes>
+                  <Route path="/" element={<Root />}>
+                    <Route element={<HomeLayout />}>
+                      <Route index element={<HomePage />} />
+                      <Route
+                        path="radio-station/:stationuuid"
+                        element={<RadioStation />}
+                      />
                     </Route>
-                    <Route path="/404" element={<NotFoundPage />} />
-                    <Route path="*" element={<NotFoundPage />} />
-                  </Routes>
-                </Suspense>
-              </ErrorBoundary>
-            </BrowserRouter>
-          </PodcastEpisodeProvider>
+                    <Route element={<PodcastLayout />}>
+                      <Route path="/podcasts" element={<PodcastHomePage />} />
+                      <Route
+                        path="/podcasts/:podcastTitle/:podcastId"
+                        element={<PodcastDetailPage />}
+                      />
+                      <Route
+                        path="/podcasts/:categoryName"
+                        element={<PodcastCategoryPage />}
+                      />
+                    </Route>
+                  </Route>
+                  <Route path="/404" element={<NotFoundPage />} />
+                  <Route path="*" element={<NotFoundPage />} />
+                </Routes>
+              </Suspense>
+            </ErrorBoundary>
+          </BrowserRouter>
         </FavouriteStationsProvider>
       </MapProvider>
     </ThemeProvider>

--- a/frontend/src/pages/PodcastLayout/PodcastLayout.tsx
+++ b/frontend/src/pages/PodcastLayout/PodcastLayout.tsx
@@ -2,6 +2,7 @@ import "./PodcastLayout.css"
 import { preconnect, prefetchDNS } from "react-dom"
 import { Outlet } from "react-router"
 import PodcastPlayer from "../../features/podcast/player/PodcastPlayer"
+import PodcastEpisodeProvider from "../../context/PodcastEpisodeProvider/PodcastEpisodeProvider"
 
 const BACKEND_ORIGIN: string = import.meta.env.VITE_BACKEND_ORIGIN
 
@@ -10,13 +11,13 @@ export default function PodcastLayout() {
   prefetchDNS(BACKEND_ORIGIN)
 
   return (
-    <>
+    <PodcastEpisodeProvider>
       <div className="sticky-top">
         <PodcastPlayer />
       </div>
       <div className="podcast-content-container">
         <Outlet />
       </div>
-    </>
+    </PodcastEpisodeProvider>
   )
 }


### PR DESCRIPTION
Resolves #192 

Moves only the podcast episode provider to the podcast route. The Map provider is used in areas where `useContext(MapContext)` is present