### PR TITLE
Fix PodcastDetailPage race condition on loading and episode state

### DIFF
--- a/frontend/src/components/LoadingDisplay/LoadingDisplay.tsx
+++ b/frontend/src/components/LoadingDisplay/LoadingDisplay.tsx
@@ -1,0 +1,16 @@
+import { PropsWithChildren } from "react"
+import Spinner from "../Spinner/Spinner"
+
+type LoadingDisplayProps = PropsWithChildren & {
+  loading: boolean
+}
+
+export default function LoadingDisplay({
+  loading,
+  children,
+}: LoadingDisplayProps) {
+  if (loading) {
+    return <Spinner isLoading={loading} />
+  }
+  return children
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,7 @@ import MapProvider from "./context/MapProvider/MapProvider.tsx"
 import FavouriteStationsProvider from "./context/FavouriteStationsProvider/FavouriteStationsProvider.tsx"
 import Root from "./Root.tsx"
 import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary.tsx"
-import Spinner from "./components/Spinner/Spinner.tsx"
+import LoadingDisplay from "./components/LoadingDisplay/LoadingDisplay.tsx"
 
 const NotFoundPage = lazy(() => import("./pages/NotFoundPage/NotFoundPage.tsx"))
 const HomeLayout = lazy(() => import("./pages/HomeLayout/HomeLayout.tsx"))
@@ -31,7 +31,7 @@ createRoot(document.getElementById("root")!).render(
       <FavouriteStationsProvider>
         <BrowserRouter>
           <ErrorBoundary fallback={<NotFoundPage />}>
-            <Suspense fallback={<Spinner isLoading={true} />}>
+            <Suspense fallback={<LoadingDisplay loading={true} />}>
               <Routes>
                 <Route path="/" element={<Root />}>
                   <Route element={<HomeLayout />}>

--- a/frontend/src/pages/podcast/PodcastCategoryPage/PodcastCategoryPage.tsx
+++ b/frontend/src/pages/podcast/PodcastCategoryPage/PodcastCategoryPage.tsx
@@ -2,8 +2,8 @@ import "./PodcastCategoryPage.css"
 import { useCallback, useEffect, useState } from "react"
 import { Link, useNavigate, useParams } from "react-router"
 import { IoArrowBackSharp } from "react-icons/io5"
+import LoadingDisplay from "../../../components/LoadingDisplay/LoadingDisplay.tsx"
 import TrendingPodcastSection from "../../../features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.tsx"
-import Spinner from "../../../components/Spinner/Spinner.tsx"
 import useTrendingPodcasts from "../../../hooks/podcast/useTrendingPodcasts.ts"
 
 export default function PodcastCategoryPage() {
@@ -52,8 +52,7 @@ export default function PodcastCategoryPage() {
       return
     }
     return (
-      <>
-        <Spinner isLoading={loading} />
+      <LoadingDisplay loading={loading}>
         <Link
           to="/podcasts"
           style={{ textDecoration: "none", width: "fit-content" }}
@@ -71,7 +70,7 @@ export default function PodcastCategoryPage() {
           trendingPodcasts={trendingPodcasts}
           onRefresh={handlePodcastRefresh}
         />
-      </>
+      </LoadingDisplay>
     )
   }
 

--- a/frontend/src/pages/podcast/PodcastDetailPage/PodcastDetailPage.tsx
+++ b/frontend/src/pages/podcast/PodcastDetailPage/PodcastDetailPage.tsx
@@ -35,6 +35,8 @@ export default function PodcastDetailPage() {
       if (podcastEpisodes && podcastEpisodes.data) {
         setPodcastEpisodes(podcastEpisodes.data.episodes)
         setPodcast(podcastEpisodes.data.podcast)
+      } else {
+        setLoading(false) // prevent infinite load on no data
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
@@ -78,7 +80,7 @@ export default function PodcastDetailPage() {
           </button>
         </Link>
         <div className="podcast-info-container">
-          {podcast && !loading && (
+          {podcast && (
             <PodcastCard podcast={podcast} customClassName="podcast-info-card">
               <PodcastCard.Artwork size={144} />
               <div>
@@ -97,7 +99,7 @@ export default function PodcastDetailPage() {
 
         <h2>Episodes</h2>
         <div className="podcast-episode-container">
-          {podcastEpisodes && !loading ? (
+          {podcastEpisodes ? (
             podcastEpisodes.map((episode) => {
               function handlePlayClick(podcastEpisode: PodcastEpisode) {
                 if (podcastEpisodeContext) {

--- a/frontend/src/pages/podcast/PodcastHomePage/PodcastHomePage.tsx
+++ b/frontend/src/pages/podcast/PodcastHomePage/PodcastHomePage.tsx
@@ -1,8 +1,8 @@
 import "./PodcastHomePage.css"
 import { useCallback, useEffect, useState } from "react"
+import LoadingDisplay from "../../../components/LoadingDisplay/LoadingDisplay.tsx"
 import TrendingPodcastSection from "../../../features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.tsx"
 import PodcastCategorySection from "../../../features/podcast/category/components/PodcastCategorySection/PodcastCategorySection.tsx"
-import Spinner from "../../../components/Spinner/Spinner.tsx"
 import useTrendingPodcasts from "../../../hooks/podcast/useTrendingPodcasts.ts"
 import usePodcastCategory from "../../../hooks/podcast/usePodcastCategory.ts"
 
@@ -49,18 +49,19 @@ export default function PodcastHomePage() {
   }, [handlePodcastCategoryRefresh, handlePodcastRefresh, sinceDaysBefore])
 
   return (
-    <div id="podcast-home-page-container">
-      <Spinner isLoading={loadingCategories || loadingPodcasts} />
-      <PodcastCategorySection
-        loading={loadingCategories}
-        categories={categories}
-        onRefresh={handlePodcastCategoryRefresh}
-      />
-      <TrendingPodcastSection
-        loading={loadingPodcasts}
-        trendingPodcasts={trendingPodcasts}
-        onRefresh={handlePodcastRefresh}
-      />
-    </div>
+    <LoadingDisplay loading={loadingCategories || loadingPodcasts}>
+      <div id="podcast-home-page-container">
+        <PodcastCategorySection
+          loading={loadingCategories}
+          categories={categories}
+          onRefresh={handlePodcastCategoryRefresh}
+        />
+        <TrendingPodcastSection
+          loading={loadingPodcasts}
+          trendingPodcasts={trendingPodcasts}
+          onRefresh={handlePodcastRefresh}
+        />
+      </div>
+    </LoadingDisplay>
   )
 }


### PR DESCRIPTION
Refactor loading display component and use it instead of the `<Spinner>` component

The race condition happens in PodcastDetailPage where the `setLoading(false)` is done and it happens before the `setPodcastEpisodes(podcastEpisodes.data.episodes)` and `setPodcast(podcastEpisodes.data.podcast)` has happened. This causes a flash of the error text placeholder `Could not get podcast episodes. Please try again later` before showing the podcast episode content
- Solution: have a `useEffect` that checks if the podcast and podcast episode state has items in it, set the loading to false then. Don't set the loading to false for the successful fetching of podcast episode data

`PodcastDetailPage.tsx` snippet
```jsx
    const fetchPodcastEpisodes = useCallback(async (podcastId: string) => {
    setLoading(true)
    abortControllerRef.current?.abort()
    abortControllerRef.current = new AbortController()
    try {
      const podcastEpisodes = await getPodcastEpisodes(
        abortControllerRef.current,
        {
          id: podcastId,
          limit: 10,
        }
      )
      if (podcastEpisodes && podcastEpisodes.data) {
        setPodcastEpisodes(podcastEpisodes.data.episodes)
        setPodcast(podcastEpisodes.data.podcast)
      } else {
        setLoading(false) // prevent infinite load on no data
      }
      // eslint-disable-next-line @typescript-eslint/no-explicit-any
    } catch (error: any) {
      toast.error(error.message)
      setLoading(false) // prevent infinite loading on error
    }
  }, [])

  useEffect(() => {
    // prevent race condition between setLoading and set podcast episodes, display of "no episode found" placeholder before podcast data set state
    if (podcast && podcastEpisodes) {
      setLoading(false)
    }
  }, [podcast, podcastEpisodes])
```