### PR TITLE
Override any podcast episode description style colors

### DIFF
--- a/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.css
+++ b/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.css
@@ -30,6 +30,11 @@
   padding-right: 1rem;
   border: 2px solid var(--disabled-element-color);
 }
+.podcast-episode-card-description * {
+  /* Override any child with style attribute that sets text color */
+  color: var(--text-color) !important;
+  background-color: var(--background-color) !important;
+}
 
 .podcast-episode-card-episode-number,
 .podcast-episode-card-season-number {


### PR DESCRIPTION
- Resolves #246 

When setting the `description` html content, the episode might have html text with the `style` attribute set with `color`. Added css to override the styles present in the html content of episode descriptions