### PR TITLE
Fix podcast image container size to reduce CLS and increase backend endpoint rate limits

### DIFF
--- a/backend/__tests__/rateLimit.test.ts
+++ b/backend/__tests__/rateLimit.test.ts
@@ -27,9 +27,13 @@ describe("GET /api/podcast/trending", () => {
       const secondResponse = await request(app)
         .get("/api/podcast/trending?limit=10")
         .set("Origin", expectedOrigin)
+      const thirdResponse = await request(app)
+        .get("/api/podcast/trending?limit=10")
+        .set("Origin", expectedOrigin)
       expect(firstResponse.status).toEqual(200)
-      expect(secondResponse.status).toEqual(429)
-      expect(secondResponse.error).toEqual(
+      expect(secondResponse.status).toEqual(200)
+      expect(thirdResponse.status).toEqual(429)
+      expect(thirdResponse.error).toEqual(
         expect.objectContaining({
           status: 429,
           text: "Too many requests, please try again later.",
@@ -56,9 +60,13 @@ describe("GET /api/podcast/search", () => {
       const secondResponse = await request(app)
         .get(url)
         .set("Origin", expectedOrigin)
+      const thirdResponse = await request(app)
+        .get(url)
+        .set("Origin", expectedOrigin)
       expect(firstResponse.status).toEqual(200)
-      expect(secondResponse.status).toEqual(429)
-      expect(secondResponse.error).toEqual(
+      expect(secondResponse.status).toEqual(200)
+      expect(thirdResponse.status).toEqual(429)
+      expect(thirdResponse.error).toEqual(
         expect.objectContaining({
           status: 429,
           text: "Too many requests, please try again later.",
@@ -84,9 +92,13 @@ describe("GET /api/podcast/episode", () => {
       const secondResponse = await request(app)
         .get(url)
         .set("Origin", expectedOrigin)
+      const thirdResponse = await request(app)
+        .get(url)
+        .set("Origin", expectedOrigin)
       expect(firstResponse.status).toEqual(200)
-      expect(secondResponse.status).toEqual(429)
-      expect(secondResponse.error).toEqual(
+      expect(secondResponse.status).toEqual(200)
+      expect(thirdResponse.status).toEqual(429)
+      expect(thirdResponse.error).toEqual(
         expect.objectContaining({
           status: 429,
           text: "Too many requests, please try again later.",
@@ -113,10 +125,13 @@ describe("GET /api/podcast/episodes", () => {
       const secondResponse = await request(app)
         .get(url)
         .set("Origin", expectedOrigin)
-
+      const thirdResponse = await request(app)
+        .get(url)
+        .set("Origin", expectedOrigin)
       expect(firstResponse.status).toEqual(200)
-      expect(secondResponse.status).toEqual(429)
-      expect(secondResponse.error).toEqual(
+      expect(secondResponse.status).toEqual(200)
+      expect(thirdResponse.status).toEqual(429)
+      expect(thirdResponse.error).toEqual(
         expect.objectContaining({
           status: 429,
           text: "Too many requests, please try again later.",

--- a/backend/middleware/rateLimiter.ts
+++ b/backend/middleware/rateLimiter.ts
@@ -2,8 +2,8 @@ import rateLimit, { Options } from "express-rate-limit"
 import { NextFunction, Request, Response } from "express"
 
 const getTrendingPodcastLimiter = rateLimit({
-  windowMs: 2 * 1000,
-  limit: 1, // Limit each IP to "X" requests per window
+  windowMs: 1 * 1000,
+  limit: 2, // Limit each IP to "X" requests per window
   standardHeaders: "draft-7",
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   handler: (
@@ -12,14 +12,14 @@ const getTrendingPodcastLimiter = rateLimit({
     next: NextFunction,
     options: Options
   ) => {
-    res.setHeader("retry-after", 2) // in seconds
+    res.setHeader("retry-after", 1) // in seconds
     res.status(options.statusCode).send(options.message)
   },
 })
 
 const getPodcastSearchLimiter = rateLimit({
   windowMs: 1 * 1000,
-  limit: 1, // Limit each IP to "X" requests per window
+  limit: 2, // Limit each IP to "X" requests per window
   standardHeaders: "draft-7",
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   handler: (
@@ -28,14 +28,14 @@ const getPodcastSearchLimiter = rateLimit({
     next: NextFunction,
     options: Options
   ) => {
-    res.setHeader("retry-after", 2) // in seconds
+    res.setHeader("retry-after", 1) // in seconds
     res.status(options.statusCode).send(options.message)
   },
 })
 
 const getPodcastEpisodesLimiter = rateLimit({
-  windowMs: 2 * 1000,
-  limit: 1, // Limit each IP to "X" requests per window
+  windowMs: 1 * 1000,
+  limit: 2, // Limit each IP to "X" requests per window
   standardHeaders: "draft-7",
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   handler: (
@@ -44,15 +44,15 @@ const getPodcastEpisodesLimiter = rateLimit({
     next: NextFunction,
     options: Options
   ) => {
-    res.setHeader("retry-after", 2) // in seconds
+    res.setHeader("retry-after", 1) // in seconds
     res.status(options.statusCode).send(options.message)
   },
 })
 
 const getPodcastEpisodeLimiter = rateLimit({
   // rate limit for get single podcast episode by podcast episode id
-  windowMs: 2 * 1000,
-  limit: 1, // Limit each IP to "X" requests per window
+  windowMs: 1 * 1000,
+  limit: 2, // Limit each IP to "X" requests per window
   standardHeaders: "draft-7",
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
   handler: (
@@ -61,7 +61,7 @@ const getPodcastEpisodeLimiter = rateLimit({
     next: NextFunction,
     options: Options
   ) => {
-    res.setHeader("retry-after", 2) // in seconds
+    res.setHeader("retry-after", 1) // in seconds
     res.status(options.statusCode).send(options.message)
   },
 })

--- a/frontend/src/components/PodcastCard/PodcastCard.css
+++ b/frontend/src/components/PodcastCard/PodcastCard.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.5rem;
+  width: fit-content;
 }
 
 .podcast-card-title-author-container {

--- a/frontend/src/components/PodcastImage/PodcastImage.tsx
+++ b/frontend/src/components/PodcastImage/PodcastImage.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { MdOutlineImageNotSupported } from "react-icons/md"
 import { getPodcastImage } from "../../api/image/podcastImage.ts"
 
@@ -23,6 +23,9 @@ export default memo(function PodcastImage({
   )
   const [imageSrc, setImageSrc] = useState<string | null>(null)
   const [srcSet, setSrcSet] = useState<string | undefined>(undefined)
+  const PODCAST_IMAGE_CONTAINER_STYLE = useMemo(() => {
+    return { width: size, height: size, padding: 0, margin: 0 }
+  }, [])
 
   const getImageSrcSet = useCallback(
     (smallImageData: string | null, largeImageData: string | null) => {
@@ -85,20 +88,25 @@ export default memo(function PodcastImage({
     getImageData()
   }, [imageUrl, size])
 
-  return !imageSrc ? (
-    <div className={imageClassName}>
-      <MdOutlineImageNotSupported size={size} title={imageNotAvailableTitle} />
+  return (
+    <div className={imageClassName} style={PODCAST_IMAGE_CONTAINER_STYLE}>
+      {imageSrc ? (
+        <img
+          className={imageClassName}
+          decoding="async"
+          src={imageSrc}
+          srcSet={srcSet}
+          fetchPriority={fetchPriority}
+          height={size}
+          width={size}
+          title={imageTitle}
+        />
+      ) : (
+        <MdOutlineImageNotSupported
+          size={size}
+          title={imageNotAvailableTitle}
+        />
+      )}
     </div>
-  ) : (
-    <img
-      className={imageClassName}
-      decoding="async"
-      src={imageSrc}
-      srcSet={srcSet}
-      fetchPriority={fetchPriority}
-      height={size}
-      width={size}
-      title={imageTitle}
-    />
   )
 })

--- a/frontend/src/features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.css
+++ b/frontend/src/features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.css
@@ -47,6 +47,7 @@
 
 .podcast-trending-card-detail-link {
   text-decoration: none;
+  width: 100%;
 }
 .podcast-trending-card-detail-link:hover {
   text-decoration: underline;


### PR DESCRIPTION
1) The `PodcastImage` component has different size for the placeholder image compared to the actual loaded image. This causes the podcast text below the title to shift (Cumulative Layout Shift (CLS)). 
    - This causes a slight CLS of 0.002 on PageSpeed Insights - https://pagespeed.web.dev/analysis/https-xtal-eight-vercel-app-podcasts/dj0m928yvq?form_factor=mobile

2) Increase the backend endpoint rate limit to two per second