### PR TITLE
Use device pixel ratio to set podcast image src set

### DIFF
--- a/frontend/src/hooks/useScreenDimensions.ts
+++ b/frontend/src/hooks/useScreenDimensions.ts
@@ -15,6 +15,8 @@ function getScreenSize() {
   }
 }
 
+const MIN_DEVICE_PIXEL_RATIO = 1
+
 export default function useScreenDimensions() {
   // https://stackoverflow.com/a/36862446
   const [screenSize, setScreenSize] = useState<ScreenSize>(getScreenSize())
@@ -32,7 +34,10 @@ export default function useScreenDimensions() {
     return {
       width: screenSize.width,
       height: screenSize.height,
-      devicePixelRatio: Math.floor(screenSize.devicePixelRatio), // round down to nearest int
+      devicePixelRatio: Math.max(
+        MIN_DEVICE_PIXEL_RATIO,
+        Math.floor(screenSize.devicePixelRatio)
+      ),
       isMobile: screenSize.width <= 576,
     }
   }, [screenSize.width, screenSize.height])

--- a/frontend/src/hooks/useScreenDimensions.ts
+++ b/frontend/src/hooks/useScreenDimensions.ts
@@ -3,13 +3,15 @@ import { useEffect, useMemo, useState } from "react"
 type ScreenSize = {
   width: number
   height: number
+  devicePixelRatio: number
 }
 
 function getScreenSize() {
-  const { innerWidth, innerHeight } = window
+  const { innerWidth, innerHeight, devicePixelRatio } = window
   return {
     width: innerWidth,
     height: innerHeight,
+    devicePixelRatio,
   }
 }
 
@@ -30,6 +32,7 @@ export default function useScreenDimensions() {
     return {
       width: screenSize.width,
       height: screenSize.height,
+      devicePixelRatio: Math.floor(screenSize.devicePixelRatio), // round down to nearest int
       isMobile: screenSize.width <= 576,
     }
   }, [screenSize.width, screenSize.height])


### PR DESCRIPTION
- Resolves #275 

- Reduces the image api call from two to one. Ensure max image size requested is 500px (backend has validation for image size, max of 500px allowed to be requested)

# References
- https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio

Before code fix
- https://www.webpagetest.org/result/250314_AiDc7J_2J6/
- ![image](https://github.com/user-attachments/assets/dec32fd1-5a53-44d3-ab79-b7ddd9dbe2c8)
