### PR TITLE
Add lazy loading to podcast images below the fold

### DIFF
--- a/frontend/src/components/PodcastCard/Artwork.tsx
+++ b/frontend/src/components/PodcastCard/Artwork.tsx
@@ -3,12 +3,14 @@ import PodcastImage from "../PodcastImage/PodcastImage.tsx"
 
 type ArtworkProps = {
   size: number
+  lazyLoad?: boolean
 }
 
-const Artwork = function PodcastCardArtwork({ size }: ArtworkProps) {
+const Artwork = function PodcastCardArtwork({ size, lazyLoad }: ArtworkProps) {
   const { podcast } = usePodcastCardContext()
   return (
     <PodcastImage
+      {...(lazyLoad && { lazyLoad: lazyLoad })}
       imageUrl={podcast.image}
       size={size}
       imageClassName="podcast-card-artwork"

--- a/frontend/src/components/PodcastEpisodeCard/Artwork.tsx
+++ b/frontend/src/components/PodcastEpisodeCard/Artwork.tsx
@@ -4,15 +4,18 @@ import PodcastImage from "../PodcastImage/PodcastImage.tsx"
 type ArtworkProps = {
   size: number
   title: string
+  lazyLoad?: boolean
 }
 
 const Artwork = function PodcastEpisodeCardArtwork({
   size,
   title,
+  lazyLoad,
 }: ArtworkProps) {
   const { episode } = usePodcastEpisodeCardContext()
   return (
     <PodcastImage
+      {...(lazyLoad && { lazyLoad: lazyLoad })}
       imageUrl={episode.image}
       size={size}
       imageClassName="podcast-episode-card-artwork"

--- a/frontend/src/components/PodcastImage/PodcastImage.tsx
+++ b/frontend/src/components/PodcastImage/PodcastImage.tsx
@@ -9,6 +9,7 @@ type PodcastImageProps = {
   imageClassName: string
   imageTitle: string
   imageNotAvailableTitle: string
+  lazyLoad?: boolean
 }
 
 export default memo(function PodcastImage({
@@ -17,6 +18,7 @@ export default memo(function PodcastImage({
   imageClassName,
   imageTitle,
   imageNotAvailableTitle,
+  lazyLoad,
 }: PodcastImageProps) {
   const { devicePixelRatio } = useScreenDimensions()
   const abortControllerRef = useRef<AbortController | null>(null)
@@ -78,6 +80,7 @@ export default memo(function PodcastImage({
     <div className={imageClassName} style={PODCAST_IMAGE_CONTAINER_STYLE}>
       {imageSrc ? (
         <img
+          {...(lazyLoad && { loading: "lazy" })}
           className={imageClassName}
           decoding="async"
           src={imageSrc}

--- a/frontend/src/features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.tsx
+++ b/frontend/src/features/podcast/trending/components/TrendingPodcastSection/TrendingPodcastSection.tsx
@@ -8,6 +8,8 @@ import useScreenDimensions from "../../../../../hooks/useScreenDimensions.ts"
 import TrendingPodcastFilters from "../TrendingPodcastFilters/TrendingPodcastFilters.tsx"
 import Button from "../../../../../components/ui/button/Button.tsx"
 
+const IMAGE_LAZY_LOAD_START_INDEX = 2 // zero based index
+
 type TrendingPodcastSectionProps = {
   trendingPodcasts: TrendingPodcast[] | null
   onRefresh: (
@@ -53,13 +55,17 @@ export default memo(function TrendingPodcastSection(
         </div>
       )
     }
-    return props.trendingPodcasts.map((podcast) => (
+    return props.trendingPodcasts.map((podcast, index) => (
       <PodcastCard
         key={podcast.id}
         customClassName="podcast-trending-card"
         podcast={podcast}
       >
-        <PodcastCard.Artwork size={isMobile ? 144 : 200} />
+        {index < IMAGE_LAZY_LOAD_START_INDEX ? (
+          <PodcastCard.Artwork size={isMobile ? 144 : 200} />
+        ) : (
+          <PodcastCard.Artwork size={isMobile ? 144 : 200} lazyLoad={true} />
+        )}
         <Link
           to={getPodcastDetailPath(podcast)}
           className="podcast-trending-card-detail-link"

--- a/frontend/src/pages/podcast/PodcastDetailPage/PodcastDetailPage.tsx
+++ b/frontend/src/pages/podcast/PodcastDetailPage/PodcastDetailPage.tsx
@@ -12,6 +12,7 @@ import Pagination from "../../../components/Pagination/Pagination.tsx"
 import Button from "../../../components/ui/button/Button.tsx"
 
 const LIMIT = 10
+const IMAGE_LAZY_LOAD_START_INDEX = 2 // zero based index
 
 export default function PodcastDetailPage() {
   const { podcastId, podcastTitle } = useParams()
@@ -106,7 +107,7 @@ export default function PodcastDetailPage() {
         <h2 className="podcast-episode-section-title">Episodes</h2>
         <div className="podcast-episode-container">
           {podcastEpisodes ? (
-            podcastEpisodes.map((episode) => {
+            podcastEpisodes.map((episode, index) => {
               function handlePlayClick(podcastEpisode: PodcastEpisode) {
                 if (podcastEpisodeContext) {
                   podcastEpisodeContext.setEpisode(podcastEpisode)
@@ -114,10 +115,18 @@ export default function PodcastDetailPage() {
               }
               return (
                 <PodcastEpisodeCard key={episode.id} episode={episode}>
-                  <PodcastEpisodeCard.Artwork
-                    size={144}
-                    title={`${episode.title} podcast image`}
-                  />
+                  {index < IMAGE_LAZY_LOAD_START_INDEX ? (
+                    <PodcastEpisodeCard.Artwork
+                      size={144}
+                      title={`${episode.title} podcast image`}
+                    />
+                  ) : (
+                    <PodcastEpisodeCard.Artwork
+                      size={144}
+                      title={`${episode.title} podcast image`}
+                      lazyLoad={true}
+                    />
+                  )}
                   <PodcastEpisodeCard.Title
                     url={`/podcasts/${podcastTitle}/${podcastId}/${episode.id}`}
                   />


### PR DESCRIPTION
Add lazy loading to images in list (from 3rd image onwards) (trending podcast section and podcast detail page (episodes))
- Resolves #286 

Before Code Change
- https://pagespeed.web.dev/analysis/https-xtal-eight-vercel-app-podcasts/wjnnkr0ml7?form_factor=mobile
- ![image](https://github.com/user-attachments/assets/fe545e8e-6c3a-4cf8-9d53-1256889b8756)
- ![image](https://github.com/user-attachments/assets/3963bb81-fb7d-42b5-8962-3f3f18cd5445)

