### PR TITLE
Fix radio browser server list

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ The Backend tests are written in vitest - https://vitest.dev/
 
 # Known Issues
 
-- Not Available
+- The radio browser API endpoints might change and the `frontend/src/api/radiobrowser/servers.ts` file needs to be updated based on response of http://all.api.radio-browser.info/json/servers
+  - The radio browser api endpoints are hard coded to avoid a network request for the servers. (Disadvantage: have to manually update the servers. Test failures for radio features could be due to server being down (check the network request))
 
 # Like this project?
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,9 +18,9 @@ dotenv.config({ path: path.resolve(__dirname, ".env.local") })
  */
 export default defineConfig({
   testDir: "./tests",
-  timeout: 10_000,
+  timeout: 25_000,
   expect: {
-    timeout: 6_000,
+    timeout: 7_000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/frontend/src/api/radiobrowser/servers.ts
+++ b/frontend/src/api/radiobrowser/servers.ts
@@ -1,8 +1,9 @@
 // Hard coded servers as requests to "http" fails with "This request has been blocked; the content must be served over HTTPS"
 // http://all.api.radio-browser.info/json/servers
 const servers: string[] = [
-  "https://at1.api.radio-browser.info",
+  "https://de1.api.radio-browser.info",
   "https://de2.api.radio-browser.info",
+  "https://fi1.api.radio-browser.info",
 ]
 const serverCount = servers.length
 


### PR DESCRIPTION
The `https://at1.api.radio-browser.info` endpoint is not working
- https://all.api.radio-browser.info/json/servers