### PR TITLE
Allow user to paginate podcast search results on podcast search page

### DIFF
--- a/backend/__tests__/route/podcast.episode.test.ts
+++ b/backend/__tests__/route/podcast.episode.test.ts
@@ -234,7 +234,9 @@ describe("GET /api/podcast/episodes", () => {
         latestPublishTime: podcastResponse.feed.lastUpdateTime,
         isExplicit: podcastResponse.feed.explicit,
         episodeCount: podcastResponse.feed.episodeCount,
-        categories: Object.values(podcastResponse.feed.categories),
+        categories: podcastResponse.feed.categories
+          ? Object.values(podcastResponse.feed.categories)
+          : [],
       },
       episodes: episodeItems.map((episode) => {
         return {

--- a/backend/__tests__/route/podcast.search.by.title.test.ts
+++ b/backend/__tests__/route/podcast.search.by.title.test.ts
@@ -110,8 +110,10 @@ describe("GET /api/podcast/search", () => {
         image: podcast.image || podcast.artwork,
         language: Language[language as keyof typeof Language],
         latestPublishTime: podcast.newestItemPubdate,
-        // @ts-ignore
-        categories: Object.values<string>(podcast.categories),
+        categories: podcast.categories
+          ? // @ts-ignore
+            Object.values<string>(podcast.categories)
+          : [],
         episodeCount: podcast.episodeCount,
         isExplicit: podcast.explicit,
       }

--- a/backend/api/model/podcast.ts
+++ b/backend/api/model/podcast.ts
@@ -21,5 +21,5 @@ export type PodcastIndexFeed = {
   episodeCount?: number
   explicit?: boolean
   language: Language
-  categories: PodcastIndexCategory
+  categories: PodcastIndexCategory | null /* could have null value */
 }

--- a/backend/api/podcastApi.ts
+++ b/backend/api/podcastApi.ts
@@ -55,7 +55,9 @@ class PodcastIndexApi implements PodcastApi {
         image: feed.image || feed.artwork || "",
         latestPublishTime: feed.newestItemPublishTime || feed.newestItemPubdate,
         language: Language[language as keyof typeof Language],
-        categories: Object.values<string>(feed.categories),
+        categories: feed.categories
+          ? Object.values<string>(feed.categories)
+          : [],
       }
     })
     return podcasts
@@ -75,7 +77,9 @@ class PodcastIndexApi implements PodcastApi {
         image: feed.image || feed.artwork || "",
         latestPublishTime: feed.newestItemPubdate,
         language: Language[language as keyof typeof Language],
-        categories: Object.values<string>(feed.categories),
+        categories: feed.categories
+          ? Object.values<string>(feed.categories)
+          : [],
         episodeCount: feed.episodeCount,
         isExplicit: feed.explicit,
       }

--- a/backend/api/podcastApi.ts
+++ b/backend/api/podcastApi.ts
@@ -155,7 +155,9 @@ class PodcastIndexApi implements PodcastApi {
       image: response.feed.image || response.feed.artwork,
       language: Language[language as keyof typeof Language],
       latestPublishTime: response.feed.lastUpdateTime,
-      categories: Object.values<string>(response.feed.categories),
+      categories: response.feed.categories
+        ? Object.values<string>(response.feed.categories)
+        : [],
       episodeCount: response.feed.episodeCount,
       isExplicit: response.feed.explicit,
     }

--- a/frontend/src/features/podcast/search/PodcastSearchResultSection/PodcastSearchResultSection.tsx
+++ b/frontend/src/features/podcast/search/PodcastSearchResultSection/PodcastSearchResultSection.tsx
@@ -32,15 +32,24 @@ const gridComponents: GridComponents<Podcast> | undefined = {
 
 type PodcastSearchResultSectionType = {
   podcasts: Podcast[]
+  onLoadMorePodcasts: () => Promise<void>
 }
 
 function PodcastSearchResultSection({
   podcasts,
+  onLoadMorePodcasts,
 }: PodcastSearchResultSectionType) {
   const { height, isMobile } = useScreenDimensions()
   const virtuosoStyle = useMemo(() => {
     return { height }
   }, [height])
+
+  const handleLoadMorePodcasts = useCallback(async () => {
+    const timeoutInMs = 1000
+    return setTimeout(() => {
+      onLoadMorePodcasts()
+    }, timeoutInMs) // to handle fetch data rate limiting
+  }, [onLoadMorePodcasts])
 
   const renderItemContent = useCallback(
     (index: number) => {
@@ -79,9 +88,11 @@ function PodcastSearchResultSection({
   return (
     <VirtuosoGrid
       style={virtuosoStyle}
-      totalCount={podcasts.length}
+      data={podcasts}
       components={gridComponents}
       itemContent={renderItemContent}
+      endReached={handleLoadMorePodcasts}
+      increaseViewportBy={100}
     />
   )
 }

--- a/frontend/src/features/podcast/search/PodcastSearchSection/PodcastSearchSection.tsx
+++ b/frontend/src/features/podcast/search/PodcastSearchSection/PodcastSearchSection.tsx
@@ -17,7 +17,7 @@ function PodcastSearchSection() {
   const handlePodcastSearch = useCallback(
     async (query: string) => {
       const podcastSearchLimit = 10
-      fetchPodcastsBySearchQuery(query, podcastSearchLimit)
+      fetchPodcastsBySearchQuery({ query: query, limit: podcastSearchLimit })
     },
     [fetchPodcastsBySearchQuery]
   )

--- a/frontend/src/hooks/podcast/usePodcastSearch.ts
+++ b/frontend/src/hooks/podcast/usePodcastSearch.ts
@@ -5,12 +5,54 @@ import { Podcast } from "../../api/podcast/model/podcast.ts"
 
 function usePodcastSearch() {
   const abortController = useRef<AbortController | null>(null)
+  const fetchMorePodcastsAbortController = useRef<AbortController | null>(null)
   const [loading, setLoading] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [podcasts, setPodcasts] = useState<Podcast[] | null>(null)
 
+  const fetchMorePodcasts = useCallback(
+    async ({ query, limit }: { query: string; limit: number }) => {
+      setLoading(true)
+      setError(null)
+      fetchMorePodcastsAbortController.current?.abort()
+      fetchMorePodcastsAbortController.current = new AbortController()
+      const params = {
+        q: query.trim(),
+        limit: limit,
+        offset: podcasts ? podcasts.length : 0,
+      }
+      try {
+        const response = await getPodcastSearch(
+          fetchMorePodcastsAbortController.current,
+          params
+        )
+        if (response && response.data && response.count > 0) {
+          const uniquePodcastIds = new Set(
+            podcasts ? podcasts.map((p) => p.id) : []
+          )
+          setPodcasts(
+            podcasts
+              ? podcasts.concat(
+                  response.data.filter((p) => !uniquePodcastIds.has(p.id))
+                )
+              : response.data
+          )
+        } else {
+          toast.info("No additional podcasts available")
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (error: any) {
+        toast.error(error.message)
+        setError(error.message)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [podcasts]
+  )
+
   const fetchPodcastsBySearchQuery = useCallback(
-    async (query: string, limit: number) => {
+    async ({ query, limit }: { query: string; limit: number }) => {
       if (query.trim() === "") {
         setPodcasts(null)
         return
@@ -22,7 +64,7 @@ function usePodcastSearch() {
       const params = { q: query.trim(), limit: limit }
       try {
         const response = await getPodcastSearch(abortController.current, params)
-        if (response && response.data) {
+        if (response && response.data && response.count > 0) {
           setPodcasts(response.data)
         } else {
           toast.info("No podcasts found for search term")
@@ -44,8 +86,9 @@ function usePodcastSearch() {
       error,
       podcasts,
       fetchPodcastsBySearchQuery,
+      fetchMorePodcasts,
     }
-  }, [loading, error, podcasts, fetchPodcastsBySearchQuery])
+  }, [loading, error, podcasts, fetchPodcastsBySearchQuery, fetchMorePodcasts])
 
   return output
 }

--- a/frontend/src/pages/podcast/PodcastSearchPage/PodcastSearchPage.tsx
+++ b/frontend/src/pages/podcast/PodcastSearchPage/PodcastSearchPage.tsx
@@ -1,5 +1,5 @@
 import "./PodcastSearchPage.css"
-import { useEffect } from "react"
+import { useCallback, useEffect } from "react"
 import { useSearchParams } from "react-router"
 import LoadingDisplay from "../../../components/LoadingDisplay/LoadingDisplay.tsx"
 import usePodcastSearch from "../../../hooks/podcast/usePodcastSearch.ts"
@@ -14,7 +14,19 @@ export default function PodcastSearchPage() {
     loading: loadingPodcasts,
     podcasts,
     fetchPodcastsBySearchQuery,
+    fetchMorePodcasts,
   } = usePodcastSearch()
+
+  const handleLoadMorePodcasts = useCallback(async () => {
+    if (!searchParams.has("q") || podcasts == null) {
+      return
+    }
+    const query = searchParams.get("q")
+    if (query == null || query.trim() === "") {
+      return
+    }
+    fetchMorePodcasts({ query: query.trim(), limit: LIMIT })
+  }, [searchParams, podcasts, fetchMorePodcasts])
 
   useEffect(() => {
     if (!searchParams.has("q")) {
@@ -32,11 +44,13 @@ export default function PodcastSearchPage() {
     if (query == null || query.trim() === "") {
       return
     }
-    fetchPodcastsBySearchQuery(query.trim(), LIMIT)
+    fetchPodcastsBySearchQuery({ query: query.trim(), limit: LIMIT })
   }, [searchParams, fetchPodcastsBySearchQuery])
 
   return (
     <div id="podcast-search-page-container">
+      {/* place LoadingDisplay standalone to prevent re-render of virtualized list */}
+      <LoadingDisplay loading={loadingPodcasts} />
       {searchParams.has("q") && (
         <div>
           Showing results for{" "}
@@ -46,9 +60,10 @@ export default function PodcastSearchPage() {
         </div>
       )}
       <PodcastSearchSection />
-      <LoadingDisplay loading={loadingPodcasts}>
-        <PodcastSearchResultSection podcasts={podcasts || []} />
-      </LoadingDisplay>
+      <PodcastSearchResultSection
+        podcasts={podcasts || []}
+        onLoadMorePodcasts={handleLoadMorePodcasts}
+      />
     </div>
   )
 }


### PR DESCRIPTION
- Resolves #380 
- **Fix null error for some "test" podcast search where the result has `categories` response data of `null`**