### PR TITLE
Add episode share button to podcast detail page

### DIFF
--- a/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.css
+++ b/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.css
@@ -37,7 +37,6 @@
 .podcast-episode-card-play-button {
   width: fit-content;
   gap: 0.1rem;
-  margin: 1rem 0;
   font-weight: bold;
   font-size: 0.9rem;
 }
@@ -63,4 +62,8 @@
   text-decoration: "none";
   width: fit-content;
   word-break: break-word;
+}
+
+.podcast-episode-card-share-button-container {
+  margin: 0.5rem 0;
 }

--- a/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.tsx
+++ b/frontend/src/components/PodcastEpisodeCard/PodcastEpisodeCard.tsx
@@ -5,7 +5,7 @@ import { PodcastEpisodeCardContext } from "./PodcastEpisodeCardContext.ts"
 import { PodcastEpisode } from "../../api/podcast/model/podcast.ts"
 import { sanitizeHtmlString } from "../../api/dom/domSanitize.ts"
 
-const podcastEpisodeCardInitial = { opacity: 0, x: 50 }
+const podcastEpisodeCardInitial = { opacity: 0, x: 100 }
 const podcastEpisodeCardAnimate = { opacity: 1, x: 0 }
 const podcastEpisodeCardWhileInView = { opacity: 1, x: 0 }
 const podcastEpisodeCardTransition = {

--- a/frontend/src/components/PodcastEpisodeCard/ShareButton.tsx
+++ b/frontend/src/components/PodcastEpisodeCard/ShareButton.tsx
@@ -42,7 +42,10 @@ const ShareButton = function PodcastEpisodeCardShareButton({
   return (
     <>
       {open && <DialogDimBackground />}
-      <div ref={clickOutsideRef}>
+      <div
+        ref={clickOutsideRef}
+        className="podcast-episode-card-share-button-container"
+      >
         <Button
           keyProp={`podcast-episode-share-button-${episode.id}`}
           data-testid="podcast-episode-share-button"

--- a/frontend/src/features/podcast/episode/PodcastEpisodeItem/PodcastEpisodeItem.tsx
+++ b/frontend/src/features/podcast/episode/PodcastEpisodeItem/PodcastEpisodeItem.tsx
@@ -1,8 +1,9 @@
 import "./PodcastEpisodeItem.css"
-import { memo } from "react"
+import { memo, useCallback } from "react"
 import PodcastEpisodeCard from "../../../../components/PodcastEpisodeCard/index.tsx"
 import { PodcastEpisode } from "../../../../api/podcast/model/podcast.ts"
 import useScreenDimensions from "../../../../hooks/useScreenDimensions.ts"
+import useClipboard from "../../../../hooks/useClipboard.ts"
 
 type PodcastEpisodeItemProps = {
   lazyLoad: boolean
@@ -18,6 +19,14 @@ function PodcastEpisodeItem({
   onPlayClick,
 }: PodcastEpisodeItemProps) {
   const { isMobile } = useScreenDimensions()
+  const { copyPodcastEpisodeShareUrl } = useClipboard()
+
+  const handleShareClick = useCallback(
+    (episode: PodcastEpisode, startDurationInSeconds: number) => {
+      copyPodcastEpisodeShareUrl(episode, startDurationInSeconds)
+    },
+    [copyPodcastEpisodeShareUrl]
+  )
 
   return (
     <PodcastEpisodeCard episode={episode}>
@@ -34,6 +43,7 @@ function PodcastEpisodeItem({
         <PodcastEpisodeCard.EpisodeNumber />
         <PodcastEpisodeCard.SeasonNumber />
       </div>
+      <PodcastEpisodeCard.ShareButton onClick={handleShareClick} />
       <PodcastEpisodeCard.PlayButton onPlayClick={onPlayClick} />
       <PodcastEpisodeCard.Description />
     </PodcastEpisodeCard>

--- a/frontend/src/pages/podcast/PodcastEpisodeDetailPage/PodcastEpisodeDetailPage.css
+++ b/frontend/src/pages/podcast/PodcastEpisodeDetailPage/PodcastEpisodeDetailPage.css
@@ -15,5 +15,4 @@
 
 .podcast-episode-detail-share-button {
   width: fit-content;
-  margin-top: 0.5rem;
 }

--- a/frontend/tests/constants/podcast/share/podcastEpisodeShareConstants.ts
+++ b/frontend/tests/constants/podcast/share/podcastEpisodeShareConstants.ts
@@ -1,0 +1,38 @@
+import { Page } from "@playwright/test"
+
+export function getPodcastEpisodeShareButton(page: Page) {
+  return page
+    .locator(".podcast-episode-card")
+    .getByTestId("podcast-episode-share-button")
+}
+
+export function getFirstPodcastEpisodeShareButton(page: Page) {
+  return page
+    .locator(".podcast-episode-card")
+    .getByTestId("podcast-episode-share-button")
+    .nth(0)
+}
+
+export function getPodcastEpisodeShareDialog(page: Page) {
+  return page.getByTestId("podcast-episode-share-dialog-content")
+}
+
+export function getPodcastEpisodeCopyLinkButton(page: Page) {
+  return page.getByTestId("podcast-episode-copy-link-button")
+}
+
+export function getPodcastEpisodeCloseDialogButton(page: Page) {
+  return page.locator(".podcast-episode-share-dialog .dialog-close-button")
+}
+
+export function getPodcastEpisodeDialogTimestampInput(page: Page) {
+  return page
+    .getByTestId("podcast-episode-share-dialog-content")
+    .locator(".podcast-episode-start-playback-time")
+}
+
+export function getPodcastEpisodePlayButton(page: Page) {
+  return page
+    .locator(".podcast-episode-card")
+    .getByRole("button", { name: "Play", exact: true })
+}

--- a/frontend/tests/podcast/detail/podcast.detail.page.share.podcast.spec.ts
+++ b/frontend/tests/podcast/detail/podcast.detail.page.share.podcast.spec.ts
@@ -3,6 +3,12 @@ import { defaultTenPodcastEpisodes } from "../../mocks/podcast.episode"
 import { assertToastMessage, HOMEPAGE } from "../../constants/homepageConstants"
 import { getPodcastInfoShareButton } from "../../constants/podcast/detail/podcastDetailConstants"
 import { getClipboardContent } from "../../constants/shareStationConstants"
+import {
+  getFirstPodcastEpisodeShareButton,
+  getPodcastEpisodeCopyLinkButton,
+  getPodcastEpisodeDialogTimestampInput,
+  getPodcastEpisodeShareDialog,
+} from "../../constants/podcast/share/podcastEpisodeShareConstants"
 
 test.describe("Share Feature of Podcast Detail Page for individual podcast /podcasts/PODCAST-TITLE/PODCAST-ID", () => {
   test("should copy podcast detail page url when podcast info section share button is clicked", async ({
@@ -27,5 +33,60 @@ test.describe("Share Feature of Podcast Detail Page for individual podcast /podc
     await podcastShareButton.click()
     expect(await getClipboardContent(page)).toBe(expectedPodcastUrl)
     await assertToastMessage(page, "Link Copied")
+  })
+
+  test.describe("podcast episode list", () => {
+    test("should open share podcast episode dialog on episode share button click", async ({
+      page,
+    }) => {
+      const podcastTitle = encodeURIComponent("Batman University")
+      const podcastId = "75075"
+      const limit = 10
+      await page.route(
+        `*/**/api/podcast/episodes?id=${podcastId}&limit=${limit}`,
+        async (route) => {
+          const json = defaultTenPodcastEpisodes
+          await route.fulfill({ json })
+        }
+      )
+      await page.goto(HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}`)
+      await expect(page).toHaveTitle(/Batman University - xtal - podcasts/)
+      await expect(getFirstPodcastEpisodeShareButton(page)).toBeVisible()
+      await getFirstPodcastEpisodeShareButton(page).click()
+      await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
+      await expect(getPodcastEpisodeCopyLinkButton(page)).toBeVisible()
+    })
+
+    test("should allow user to copy first share podcast episode link at specific timestamp", async ({
+      page,
+    }) => {
+      const expectedStartDurationInSeconds = "30"
+      const podcastTitle = encodeURIComponent("Batman University")
+      const podcastId = "75075"
+      const limit = 10
+      const podcastEpisodeId = defaultTenPodcastEpisodes.data.episodes[0].id
+      await page.route(
+        `*/**/api/podcast/episodes?id=${podcastId}&limit=${limit}`,
+        async (route) => {
+          const json = defaultTenPodcastEpisodes
+          await route.fulfill({ json })
+        }
+      )
+      const expectedPodcastEpisodeUrl =
+        HOMEPAGE +
+        `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}?t=${expectedStartDurationInSeconds}`
+      await page.goto(HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}`)
+      await expect(page).toHaveTitle(/Batman University - xtal - podcasts/)
+      await expect(getFirstPodcastEpisodeShareButton(page)).toBeVisible()
+      await getFirstPodcastEpisodeShareButton(page).click()
+      await expect(getPodcastEpisodeDialogTimestampInput(page)).toBeVisible()
+      await getPodcastEpisodeDialogTimestampInput(page).fill(
+        expectedStartDurationInSeconds
+      )
+      await expect(getPodcastEpisodeCopyLinkButton(page)).toBeVisible()
+      await getPodcastEpisodeCopyLinkButton(page).click()
+      expect(await getClipboardContent(page)).toBe(expectedPodcastEpisodeUrl)
+      await assertToastMessage(page, "Link Copied")
+    })
   })
 })

--- a/frontend/tests/podcast/detail/podcast.episode.detail.page.share.spec.ts
+++ b/frontend/tests/podcast/detail/podcast.episode.detail.page.share.spec.ts
@@ -2,38 +2,16 @@ import test, { expect, Page } from "@playwright/test"
 import { podcastId_259760_episodeId_34000697601 } from "../../mocks/podcast.episode"
 import { assertToastMessage, HOMEPAGE } from "../../constants/homepageConstants"
 import { getClipboardContent } from "../../constants/shareStationConstants"
+import {
+  getPodcastEpisodeCloseDialogButton,
+  getPodcastEpisodeCopyLinkButton,
+  getPodcastEpisodeShareButton,
+  getPodcastEpisodeDialogTimestampInput,
+  getPodcastEpisodePlayButton,
+  getPodcastEpisodeShareDialog,
+} from "../../constants/podcast/share/podcastEpisodeShareConstants"
 
 test.describe("Share Feature of Podcast Episode Detail Page for viewing single podcast episode /podcasts/PODCAST-TITLE/PODCAST-ID/PODCAST-EPISODE-ID", () => {
-  function getPodcastEpisodeDetailShareButton(page: Page) {
-    return page
-      .locator(".podcast-episode-card")
-      .getByTestId("podcast-episode-share-button")
-  }
-
-  function getPodcastEpisodeShareDialog(page: Page) {
-    return page.getByTestId("podcast-episode-share-dialog-content")
-  }
-
-  function getPodcastEpisodeCopyLinkButton(page: Page) {
-    return page.getByTestId("podcast-episode-copy-link-button")
-  }
-
-  function getPodcastEpisodeCloseDialogButton(page: Page) {
-    return page.locator(".podcast-episode-share-dialog .dialog-close-button")
-  }
-
-  function getPodcastEpisodeDialogTimestampInput(page: Page) {
-    return page
-      .getByTestId("podcast-episode-share-dialog-content")
-      .locator(".podcast-episode-start-playback-time")
-  }
-
-  function getPodcastEpisodePlayButton(page: Page) {
-    return page
-      .locator(".podcast-episode-card")
-      .getByRole("button", { name: "Play", exact: true })
-  }
-
   async function assertPodcastPlayerCurrentTime(
     page: Page,
     isMobile: boolean,
@@ -70,8 +48,8 @@ test.describe("Share Feature of Podcast Episode Detail Page for viewing single p
     await page.goto(
       HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}`
     )
-    await expect(getPodcastEpisodeDetailShareButton(page)).toBeVisible()
-    await getPodcastEpisodeDetailShareButton(page).click()
+    await expect(getPodcastEpisodeShareButton(page)).toBeVisible()
+    await getPodcastEpisodeShareButton(page).click()
     await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
   })
 
@@ -91,8 +69,8 @@ test.describe("Share Feature of Podcast Episode Detail Page for viewing single p
     await page.goto(
       HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}`
     )
-    await expect(getPodcastEpisodeDetailShareButton(page)).toBeVisible()
-    await getPodcastEpisodeDetailShareButton(page).click()
+    await expect(getPodcastEpisodeShareButton(page)).toBeVisible()
+    await getPodcastEpisodeShareButton(page).click()
     await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
     // click outside modal
     await page.locator("body").click({ position: { x: 1, y: 1 } })
@@ -115,8 +93,8 @@ test.describe("Share Feature of Podcast Episode Detail Page for viewing single p
     await page.goto(
       HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}`
     )
-    await expect(getPodcastEpisodeDetailShareButton(page)).toBeVisible()
-    await getPodcastEpisodeDetailShareButton(page).click()
+    await expect(getPodcastEpisodeShareButton(page)).toBeVisible()
+    await getPodcastEpisodeShareButton(page).click()
     await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
     await expect(getPodcastEpisodeCloseDialogButton(page)).toBeVisible()
     await getPodcastEpisodeCloseDialogButton(page).click()
@@ -141,8 +119,8 @@ test.describe("Share Feature of Podcast Episode Detail Page for viewing single p
     await page.goto(
       HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}`
     )
-    await expect(getPodcastEpisodeDetailShareButton(page)).toBeVisible()
-    await getPodcastEpisodeDetailShareButton(page).click()
+    await expect(getPodcastEpisodeShareButton(page)).toBeVisible()
+    await getPodcastEpisodeShareButton(page).click()
     await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
     await expect(getPodcastEpisodeCopyLinkButton(page)).toBeVisible()
     await getPodcastEpisodeCopyLinkButton(page).click()
@@ -170,8 +148,8 @@ test.describe("Share Feature of Podcast Episode Detail Page for viewing single p
     await page.goto(
       HOMEPAGE + `/podcasts/${podcastTitle}/${podcastId}/${podcastEpisodeId}`
     )
-    await expect(getPodcastEpisodeDetailShareButton(page)).toBeVisible()
-    await getPodcastEpisodeDetailShareButton(page).click()
+    await expect(getPodcastEpisodeShareButton(page)).toBeVisible()
+    await getPodcastEpisodeShareButton(page).click()
     await expect(getPodcastEpisodeShareDialog(page)).toBeVisible()
 
     await expect(getPodcastEpisodeDialogTimestampInput(page)).toBeVisible()


### PR DESCRIPTION
- Resolves #420 

### Example `http://localhost:5173/podcasts/Eggplant%3A%20The%20Secret%20Lives%20of%20Games/439116`
![Image](https://github.com/user-attachments/assets/f4df21f7-44cf-41e4-8efc-7c3352621d7b)

![Image](https://github.com/user-attachments/assets/cd56c7f4-9db5-4394-9320-df7f18bb5c0b)