### PR TITLE
Fix dialog background size and about page image size

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-blob-report-${{ matrix.shardIndex }}
-          path: frontend/playwright-blob-report
+          path: playwright-blob-report
           retention-days: 1
 
   merge-reports:
@@ -59,16 +59,16 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: all-blob-reports
-          pattern: blob-report-*
+          path: ./playwright-blob-report
+          pattern: playwright-blob-report-*
           merge-multiple: true
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        run: npx playwright merge-reports --reporter html ./playwright-blob-report
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
           name: html-report--attempt-${{ github.run_attempt }}
-          path: frontend/playwright-report
+          path: playwright-report
           retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npx playwright test --reporter=blob --output playwright-blob-report --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
@@ -59,7 +59,7 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: ./playwright-blob-report
+          path: playwright-blob-report
           pattern: playwright-blob-report-*
           merge-multiple: true
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,10 +36,10 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          # Needs to match blob reporter outputDir in playwright.config.ts
+          # use default blob-report name - https://playwright.dev/docs/test-reporters#blob-reporter
           # upload-artifact action does not use "working-directory" path. Needs to be relative path from root - https://github.com/actions/upload-artifact/issues/232
-          name: playwright-blob-report-${{ matrix.shardIndex }}
-          path: frontend/playwright-blob-report
+          name: blob-report-${{ matrix.shardIndex }}
+          path: frontend/blob-report
           retention-days: 1
 
   merge-reports:
@@ -61,16 +61,16 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: playwright-blob-report
-          pattern: playwright-blob-report-*
+          path: blob-report
+          pattern: blob-report-*
           merge-multiple: true
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./playwright-blob-report
+        run: npx playwright merge-reports --reporter html ./blob-report
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
           name: html-report--attempt-${{ github.run_attempt }}
-          path: playwright-report
+          path: frontend/playwright-report
           retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,12 +5,17 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  test:
+  playwright-tests:
     timeout-minutes: 60
     defaults:
       run:
         working-directory: frontend
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,10 +31,42 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test
-      - uses: actions/upload-artifact@v4
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-blob-report-${{ matrix.shardIndex }}
+          path: frontend/playwright-blob-report
+          retention-days: 1
+
+  merge-reports:
+    # Merge reports after playwright-tests, even if some shards have failed
+    if: ${{ !cancelled() }}
+    needs: [playwright-tests]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports from GitHub Actions Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      - name: Merge into HTML Report
+        run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report--attempt-${{ github.run_attempt }}
           path: frontend/playwright-report
-          retention-days: 20
+          retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -44,7 +44,9 @@ jobs:
     # Merge reports after playwright-tests, even if some shards have failed
     if: ${{ !cancelled() }}
     needs: [playwright-tests]
-
+    defaults:
+      run:
+        working-directory: frontend
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npx playwright test --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,8 +37,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           # Needs to match blob reporter outputDir in playwright.config.ts
+          # upload-artifact action does not use "working-directory" path. Needs to be relative path from root - https://github.com/actions/upload-artifact/issues/232
           name: playwright-blob-report-${{ matrix.shardIndex }}
-          path: playwright-blob-report
+          path: frontend/playwright-blob-report
           retention-days: 1
 
   merge-reports:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Download blob reports from GitHub Actions Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: blob-report
+          path: frontend/blob-report
           pattern: blob-report-*
           merge-multiple: true
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx playwright test --reporter=blob --output playwright-blob-report --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+        run: npx playwright test --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - name: Upload blob report to GitHub Actions Artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
+          # Needs to match blob reporter outputDir in playwright.config.ts
           name: playwright-blob-report-${{ matrix.shardIndex }}
           path: playwright-blob-report
           retention-days: 1

--- a/backend/middleware/rateLimiter.ts
+++ b/backend/middleware/rateLimiter.ts
@@ -131,7 +131,7 @@ const getPodcastRecentLimiter = rateLimit({
 })
 
 const getStatusLimiter = rateLimit({
-  windowMs: 2 * 1000,
+  windowMs: 1 * 1000,
   limit: 1, // Limit each IP to "X" requests per window
   standardHeaders: "draft-7",
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -141,7 +141,7 @@ const getStatusLimiter = rateLimit({
     next: NextFunction,
     options: Options
   ) => {
-    res.setHeader("retry-after", 2) // in seconds
+    res.setHeader("retry-after", 1) // in seconds
     res.status(options.statusCode).send(options.message)
   },
 })

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -133,6 +133,7 @@ await page.route("*/**/api/podcast/trending?limit=10", async (route) => {
 14. Vite code splitting that works - https://sambitsahoo.com/blog/vite-code-splitting-that-works.html
 15. Prevent stream from being loaded when player is closed - https://github.com/muxinc/media-elements/discussions/82
 16. Reverse Scrolling Flickering/Jumping with Dynamic Heights - react-virtuoso (add explicit width and height values and change margin to padding) - https://github.com/petyosi/react-virtuoso/discussions/1083
+17. Playwright test sharding - https://playwright.dev/docs/test-sharding#introduction
 
 # React + TypeScript + Vite
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,9 +31,7 @@ export default defineConfig({
   /* Run parallel tests with 3 workers for CI */
   workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI
-    ? [["blob", { outputDir: "playwright-blob-report" }]] // needs to match the github action folder for blob report
-    : "html",
+  reporter: process.env.CI ? "blob" : "html",
   // Limit the number of failures on CI to save resources
   maxFailures: process.env.CI ? 20 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,9 @@ export default defineConfig({
   /* Run parallel tests with 3 workers for CI */
   workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "blob" : "html",
+  // Limit the number of failures on CI to save resources
+  maxFailures: process.env.CI ? 20 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -31,7 +31,9 @@ export default defineConfig({
   /* Run parallel tests with 3 workers for CI */
   workers: process.env.CI ? 3 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? "blob" : "html",
+  reporter: process.env.CI
+    ? [["blob", { outputDir: "playwright-blob-report" }]] // needs to match the github action folder for blob report
+    : "html",
   // Limit the number of failures on CI to save resources
   maxFailures: process.env.CI ? 20 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/frontend/src/components/Dialog/Dialog.css
+++ b/frontend/src/components/Dialog/Dialog.css
@@ -35,14 +35,15 @@
   gap: 1rem;
   width: 100%;
   margin-top: 1rem;
+  z-index: 1000;
 }
 
 .dialog-dim-background {
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   background-color: rgba(0, 0, 0, 0.6);
   z-index: 1000;
 }

--- a/frontend/src/pages/AboutPage/AboutPage.css
+++ b/frontend/src/pages/AboutPage/AboutPage.css
@@ -58,6 +58,11 @@
 .jeremy-profile-picture {
   border-radius: 16px;
   margin: auto;
+  width: min(
+    70vw,
+    500px
+  ); /* Fix incorrect values for window.innerWidth on mobile first load, should be same as the size of profile picture in code */
+  height: auto;
 }
 
 @media (max-width: 430px) {

--- a/frontend/tests/about/about.page.spec.ts
+++ b/frontend/tests/about/about.page.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "../fixture/test"
 import { expect, Page } from "@playwright/test"
+import { SidebarMenuItemAction } from "../pageComponents/Sidebar"
 
 test.describe("About Page", () => {
   async function mockCurrentTotalPodcastStatistics(
@@ -101,5 +102,28 @@ test.describe("About Page", () => {
         "54805 Radio Stations in 238 Countries — https://www.radio-browser.info/"
       )
     ).toBeVisible()
+  })
+
+  test("should display mobile profile picture of correct size on first page load after navigation from another page", async ({
+    isMobile,
+    homePage,
+    aboutPage,
+  }) => {
+    test.skip(!isMobile, "Skip mobile test")
+    await homePage.goto()
+    await homePage.getSidebarToggleButton().click()
+    await expect(homePage.getSidebar()).toBeVisible()
+    await homePage.getSidebarMenuItem(SidebarMenuItemAction.About).click()
+
+    await expect(aboutPage.getJeremyProfilePicture()).toBeVisible()
+    const profilePictureBox = await aboutPage
+      .getJeremyProfilePicture()
+      .boundingBox()
+    expect(profilePictureBox).not.toBeNull()
+    const viewport = aboutPage.getPage().viewportSize()
+    expect(viewport).not.toBeNull()
+
+    expect(profilePictureBox!.width).toBeLessThan(viewport!.width)
+    expect(profilePictureBox!.height).toBe(profilePictureBox!.width)
   })
 })

--- a/frontend/tests/homepage.app.theme.spec.ts
+++ b/frontend/tests/homepage.app.theme.spec.ts
@@ -91,4 +91,31 @@ test.describe("header app theme (start with dark mode)", () => {
     await expect(homePage.getPage()).toHaveURL(podcastHomePageUrl())
     await assertElementHasLightTheme(homePage.getPage(), "#root")
   })
+
+  test("should not switch theme when navigating to multiple new pages", async ({
+    homePage,
+  }) => {
+    await homePage.goto()
+    await assertLoadingSpinnerIsMissing(homePage.getPage())
+    await assertElementHasDarkTheme(homePage.getPage(), "#root")
+    await homePage.toggleAppTheme()
+
+    await homePage.getSidebarToggleButton().click()
+    await expect(homePage.getSidebar()).toBeVisible()
+    await homePage.getSidebarMenuItem(SidebarMenuItemAction.Podcasts).click()
+    await expect(homePage.getPage()).toHaveURL(podcastHomePageUrl())
+    await assertElementHasLightTheme(homePage.getPage(), "#root")
+
+    await homePage.getSidebarToggleButton().click()
+    await expect(homePage.getSidebar()).toBeVisible()
+    await homePage
+      .getSidebarMenuItem(SidebarMenuItemAction.PodcastSearch)
+      .click()
+    await assertElementHasLightTheme(homePage.getPage(), "#root")
+
+    await homePage.getSidebarToggleButton().click()
+    await expect(homePage.getSidebar()).toBeVisible()
+    await homePage.getSidebarMenuItem(SidebarMenuItemAction.About).click()
+    await assertElementHasLightTheme(homePage.getPage(), "#root")
+  })
 })

--- a/frontend/tests/pageObjects/HomePage.ts
+++ b/frontend/tests/pageObjects/HomePage.ts
@@ -220,6 +220,9 @@ class HomePage {
   async clickRandomRadioStationButton() {
     await expect(
       this.page.getByTestId("random-radio-station-button")
+    ).toBeVisible()
+    await expect(
+      this.page.getByTestId("random-radio-station-button")
     ).toBeEnabled()
     await this.page.getByTestId("random-radio-station-button").click()
   }


### PR DESCRIPTION
Resolves #449 

**Fix about page image size not retrieving the correct `window.innerWidth` on mobile first page load**
- Load homepage (`/`)
- Navigate to about page (`/about`)
- The profile picture image should not be bigger than the viewport width
- Fix was to add CSS style to set the width and height of the image. The width obtained from `useScreenDimensions()` custom hook was not correct until the `useEffect` was set

**Fix dialog background width to be `100vw` and `100vh` instead of percentage (`100%`)**