### PR TITLE
Set dialog max width to 500px and increase player control icon size

### DIFF
--- a/frontend/src/components/Dialog/Dialog.css
+++ b/frontend/src/components/Dialog/Dialog.css
@@ -8,11 +8,9 @@
 }
 
 .dialog {
-  width: 100%;
-  min-width: 408px;
-  max-width: 50%;
+  width: clamp(300px, 80vw, 500px);
   height: fit-content;
-  max-height: 50vh;
+  max-height: 60vh;
   border-radius: 8px;
   border: 1px solid var(--text-color);
   padding: 1rem;

--- a/frontend/src/features/podcast/player/PodcastPlayer.css
+++ b/frontend/src/features/podcast/player/PodcastPlayer.css
@@ -2,6 +2,10 @@ media-controller {
   --media-primary-color: #fafafa; /* text color */
   --media-secondary-color: #0a0a0a; /* background color */
   --media-control-hover-background: #404040; /* hover background */
+  --media-font-family: monospace, Inter, system-ui, Helvetica, sans-serif;
+  --media-font-size: 1rem;
+  --media-button-icon-height: 1.5rem;
+  --media-tooltip-padding: 0.5rem;
 }
 
 media-time-range {

--- a/frontend/src/features/radio/player/RadioPlayer.css
+++ b/frontend/src/features/radio/player/RadioPlayer.css
@@ -1,7 +1,23 @@
+media-controller {
+  width: 100%;
+  --media-font-family: monospace, Inter, system-ui, Helvetica, sans-serif;
+  --media-font-size: 1rem;
+  --media-control-padding: 0.3rem; /* prevent control icons from being small due to padding */
+  --media-tooltip-padding: 0.5rem;
+  --media-tooltip-z-index: 2;
+  --media-control-height: 2rem;
+  --media-button-icon-width: 2rem;
+  --media-button-icon-height: 2rem;
+}
+
 .radio-player-container {
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
+}
+
+.audio-player {
   width: 100%;
 }
 
@@ -18,6 +34,11 @@
   }
   .desktop {
     display: none !important;
+  }
+  media-controller {
+    --media-control-height: 1.5rem;
+    --media-button-icon-width: 1.5rem;
+    --media-button-icon-height: 1.5rem;
   }
 }
 


### PR DESCRIPTION
The dialog width `max-width: 50%;` is too wide on desktop devices and looks strange

Change the width to be a min of 300px and max of 500px, with ideal of 80vw